### PR TITLE
feat(iota-core,iota-protocol-config): add per-epoch object bookkeeping for P-COOL deterministic validation

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1806,9 +1806,9 @@ impl AuthorityPerEpochStore {
     }
 
     /// The sync-ahead record for `id`.
-    pub fn sync_record(&self, id: &ObjectId) -> IotaResult<Option<SyncAheadRecord>> {
+    pub fn sync_ahead_record(&self, id: &ObjectId) -> IotaResult<Option<SyncAheadRecord>> {
         let tables = self.tables()?;
-        self.handler_object_state.sync_record(&tables, id)
+        self.handler_object_state.sync_ahead_record(&tables, id)
     }
 
     /// The sheltered bytes of a consumed input version.

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -59,7 +59,8 @@ use iota_types::{
         ConsensusTransactionKind, SignedAuthorityCapabilitiesV1, TransactionDenyRuleProposal,
         VerifiedAuthorityCapabilitiesV1, VersionedDkgConfirmation,
     },
-    storage::{BackingPackageStore, InputKey},
+    object::Object,
+    storage::{BackingPackageStore, InputKey, ObjectKey},
     transaction::{
         CertifiedTransaction, InputObjectKind, SenderSignedTransactionAPI, TransactionAPI,
         TransactionEnvelope, TransactionKey, TxValidityCheckContext, VerifiedCertificate,
@@ -157,6 +158,9 @@ pub(crate) type EncG = bls12381::G2Element;
 #[path = "consensus_quarantine.rs"]
 pub(crate) mod consensus_quarantine;
 
+#[path = "handler_object_state.rs"]
+pub mod handler_object_state;
+
 #[path = "misbehavior.rs"]
 pub(crate) mod misbehavior;
 #[path = "misbehavior_monitor.rs"]
@@ -169,6 +173,7 @@ pub(crate) mod scorer;
 use consensus_quarantine::{
     ConsensusCommitOutput, ConsensusOutputCache, ConsensusOutputQuarantine,
 };
+use handler_object_state::{HandlerLatestObject, HandlerObjectState, SyncAheadRecord};
 use iota_types::crypto::AuthorityPublicKey;
 use scorer::Scoreboard;
 
@@ -685,6 +690,10 @@ pub struct AuthorityPerEpochStore {
     /// Holds various data from consensus_quarantine in a more easily
     /// accessible form.
     consensus_output_cache: ConsensusOutputCache,
+    /// P-COOL deterministic-validation bookkeeping: the digest -> commit-round
+    /// map and the overlays over the three bookkeeping tables, holding
+    /// entries not yet durable.
+    handler_object_state: HandlerObjectState,
 
     protocol_config: ProtocolConfig,
 
@@ -830,6 +839,25 @@ pub struct AuthorityEpochTables {
     /// Map from ObjectReference to transaction locking that object
     #[default_options_override_fn = "owned_object_locked_transactions_table_default_config"]
     owned_object_locked_transactions: DBMap<ObjectReference, LockDetailsWrapper>,
+
+    /// Latest object state as of the handler frontier, for P-COOL
+    /// deterministic post-consensus validation (see [`handler_object_state`]
+    /// for the three-view design). Flushed through each commit's quarantined
+    /// `ConsensusCommitOutput`, atomically with `last_consensus_stats`. Same
+    /// access profile as the lock table: one write per touched object per
+    /// commit, one point lookup per validated input.
+    #[default_options_override_fn = "owned_object_locked_transactions_table_default_config"]
+    handler_latest_objects: DBMap<ObjectId, HandlerLatestObject>,
+
+    /// Sync-ahead records (see [`handler_object_state`]); empty in normal
+    /// operation.
+    sync_ahead_records: DBMap<ObjectId, SyncAheadRecord>,
+
+    /// Sheltered consumed-input bytes (see [`handler_object_state`]), made
+    /// durable before the executed-checkpoint watermark bump that lets the
+    /// pruner delete the perpetual rows; empty in normal operation.
+    #[default_options_override_fn = "sheltered_objects_table_default_config"]
+    sheltered_objects: DBMap<ObjectKey, Object>,
 
     /// Signatures over transaction effects that we have signed and returned to
     /// users. We store this to avoid re-signing the same effects twice.
@@ -1030,6 +1058,12 @@ fn owned_object_locked_transactions_table_default_config() -> DBOptions {
 }
 
 fn pending_consensus_transactions_table_default_config() -> DBOptions {
+    default_db_options()
+        .optimize_for_write_throughput()
+        .optimize_for_large_values_no_scan(1 << 10)
+}
+
+fn sheltered_objects_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
         .optimize_for_large_values_no_scan(1 << 10)
@@ -1273,6 +1307,7 @@ impl AuthorityPerEpochStore {
         );
 
         let consensus_output_cache = ConsensusOutputCache::new(&tables);
+        let handler_object_state = HandlerObjectState::new(&tables);
 
         // Seed the quarantine's in-memory overload-notification cache from the
         // persisted table. This is the only point we iterate the table; all
@@ -1326,6 +1361,7 @@ impl AuthorityPerEpochStore {
             protocol_config,
             tables: ArcSwapOption::new(Some(Arc::new(tables))),
             consensus_output_cache,
+            handler_object_state,
             consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
                 highest_executed_checkpoint,
                 cached_overload_notifications,
@@ -1720,6 +1756,111 @@ impl AuthorityPerEpochStore {
         } else {
             Ok(tables.transaction_key_to_digest.get(key).expect("db error"))
         }
+    }
+
+    /// Registers the kept transactions of commit `round` in the digest ->
+    /// commit-round map. Must be called while the handler processes the
+    /// commit, before any of its transactions can be scheduled: the execution
+    /// hook classifies each execution by this map - hit means the handler has
+    /// passed the producing commit, miss means state sync is running ahead.
+    pub fn assign_commit_to_transactions(
+        &self,
+        round: CommitRound,
+        digests: Vec<TransactionDigest>,
+    ) {
+        self.handler_object_state.assign_commit(round, digests);
+    }
+
+    /// Records one executed transaction's object writes for the P-COOL
+    /// deterministic-validation bookkeeping; see
+    /// [`HandlerObjectState::record_executed_transaction`].
+    pub fn record_executed_transaction(
+        &self,
+        effects: &TransactionEffects,
+        loaded_input_objects: &[Object],
+    ) -> IotaResult {
+        let tables = self.tables()?;
+        self.handler_object_state.record_executed_transaction(
+            &tables,
+            effects,
+            loaded_input_objects,
+        )
+    }
+
+    /// Marks commit `round` fully executed; see
+    /// [`HandlerObjectState::record_commit_fully_executed`].
+    pub fn record_commit_fully_executed(
+        &self,
+        round: CommitRound,
+        upserts: &[(ObjectId, HandlerLatestObject)],
+    ) -> IotaResult {
+        let tables = self.tables()?;
+        self.handler_object_state
+            .record_commit_fully_executed(&tables, round, upserts)
+    }
+
+    /// The latest state of `id` as of the handler frontier.
+    pub fn handler_latest(&self, id: &ObjectId) -> IotaResult<Option<HandlerLatestObject>> {
+        let tables = self.tables()?;
+        self.handler_object_state.handler_latest(&tables, id)
+    }
+
+    /// The sync-ahead record for `id`.
+    pub fn sync_record(&self, id: &ObjectId) -> IotaResult<Option<SyncAheadRecord>> {
+        let tables = self.tables()?;
+        self.handler_object_state.sync_record(&tables, id)
+    }
+
+    /// The sheltered bytes of a consumed input version.
+    pub fn sheltered_object(&self, key: &ObjectKey) -> IotaResult<Option<Arc<Object>>> {
+        let tables = self.tables()?;
+        self.handler_object_state.sheltered_object(&tables, key)
+    }
+
+    #[cfg(test)]
+    pub fn handler_object_state_for_testing(&self) -> &HandlerObjectState {
+        &self.handler_object_state
+    }
+
+    /// Durably writes a commit's handler-latest rows (draining queued
+    /// sync-record deletions into the same batch) and then evicts them from
+    /// the overlay, in that order - the quarantine-flush path.
+    #[cfg(test)]
+    pub fn flush_commit_rows_for_testing(
+        &self,
+        handler_rows: Vec<(ObjectId, HandlerLatestObject)>,
+    ) -> IotaResult {
+        let tables = self.tables()?;
+        let mut batch = tables.handler_latest_objects.batch();
+        self.handler_object_state
+            .write_commit_rows_to_batch(&tables, &mut batch, &handler_rows)?;
+        batch.write()?;
+        self.handler_object_state
+            .evict_flushed_commit_rows(&handler_rows);
+        Ok(())
+    }
+
+    /// Durably writes a sync-executed checkpoint's records and sheltered
+    /// bytes and then evicts them from the overlays, in that order - the
+    /// checkpoint-executor auxiliary-batch path.
+    #[cfg(test)]
+    pub fn flush_sync_ahead_rows_for_testing(
+        &self,
+        sync_rows: Vec<(ObjectId, SyncAheadRecord)>,
+        shelter_rows: Vec<(ObjectKey, Arc<Object>)>,
+    ) -> IotaResult {
+        let tables = self.tables()?;
+        let mut batch = tables.sync_ahead_records.batch();
+        self.handler_object_state.write_sync_ahead_rows_to_batch(
+            &tables,
+            &mut batch,
+            &sync_rows,
+            &shelter_rows,
+        )?;
+        batch.write()?;
+        self.handler_object_state
+            .evict_flushed_sync_ahead_rows(&sync_rows, &shelter_rows);
+        Ok(())
     }
 
     pub fn revert_executed_transaction(&self, tx_digest: &TransactionDigest) -> IotaResult {

--- a/crates/iota-core/src/authority/handler_object_state.rs
+++ b/crates/iota-core/src/authority/handler_object_state.rs
@@ -1,0 +1,973 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-epoch object bookkeeping for P-COOL deterministic post-consensus
+//! validation: object state as of the commit height being processed by the
+//! consensus handler, independent of local execution and state-sync progress.
+//!
+//! Three views are kept, each an epoch table plus an in-memory overlay
+//! holding the entries not yet durable:
+//! - **handler-latest** - the latest state of every object touched by a commit
+//!   the handler has processed, one row per object, overwritten in place. Blind
+//!   to execution driven by state sync running ahead of the handler.
+//! - **sync-ahead records** - per-object markers written by state-sync-driven
+//!   execution the handler has not reached yet, restoring the pre-sync view
+//!   (`base_version` is the version the chain grew from - latest before sync
+//!   ran ahead; `None` for an object the sync-ahead chain itself created).
+//!   Empty in normal operation.
+//! - **sheltered objects** - full bytes of input versions consumed by
+//!   sync-driven execution, kept until the handler passes the consuming commit,
+//!   so content reads survive aggressive pruning. Empty in normal operation.
+//!
+//! [`HandlerObjectState`] owns the overlays, the digest -> commit-round map,
+//! and every invariant on them: overlay-first reads, version-monotone
+//! upserts, and eviction only after the corresponding table row is durable.
+//!
+//! The in-memory state changes at five points: the handler registers a
+//! commit's kept digests before they can be scheduled
+//! ([`HandlerObjectState::assign_commit`], via the epoch store); each
+//! execution records its writes before they become readable - handler-latest
+//! rows when the digest is in the round map, sync-ahead records and sheltered
+//! bytes when it is not ([`HandlerObjectState::record_executed_transaction`]);
+//! a fully executed commit applies its remaining upserts, queues durable
+//! deletions for the sync records it caught up past, and drops its map
+//! entries ([`HandlerObjectState::record_commit_fully_executed`]); and the
+//! two eviction methods below clear overlay entries once their rows are
+//! durable.
+//!
+//! Durable writes happen at exactly two trigger points; everything else the
+//! module does is in-memory plus point reads:
+//! - the quarantine flush of a commit's output (once its checkpoint is
+//!   certified and executed): inserts the commit's handler-latest rows
+//!   atomically with `last_consensus_stats`, and drains the queued sync-record
+//!   deletions ([`HandlerObjectState::write_commit_rows_to_batch`]);
+//! - the checkpoint executor's auxiliary batch for a sync-executed checkpoint,
+//!   durable before the watermark bump: inserts sync-ahead records and
+//!   sheltered bytes ([`HandlerObjectState::write_sync_ahead_rows_to_batch`]).
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use dashmap::DashMap;
+use iota_common::{debug_fatal, random_util::randomize_cache_capacity_in_tests};
+use iota_sdk_types::{
+    ObjectDigest, ObjectId, OwnedObjectReference, Owner, TransactionDigest, TransactionEffects,
+    Version, WriteKind,
+};
+use iota_types::{
+    base_types::CommitRound,
+    effects::{TransactionEffectsAPI, TransactionEffectsExt},
+    error::IotaResult,
+    object::Object,
+    storage::ObjectKey,
+};
+use itertools::chain;
+use parking_lot::{Mutex, RwLock};
+use serde::{Deserialize, Serialize};
+use typed_store::{Map, rocks::DBBatch};
+
+use super::AuthorityEpochTables;
+use crate::execution_cache::cache_types::{IsNewer, MonotonicCache, Ticket};
+
+/// Whether a handler-latest row describes a live object or a tombstone.
+///
+/// `Deleted` and `Wrapped` yield the same drop verdict; the split mirrors the
+/// store's two tombstone digests and their different futures - a wrapped
+/// object can reappear via unwrap at a higher version, a deleted one never
+/// does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HandlerLatestObjectKind {
+    Live,
+    Deleted,
+    Wrapped,
+}
+
+/// The latest state of an object as of the consensus handler's frontier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandlerLatestObject {
+    pub version: Version,
+    pub digest: ObjectDigest,
+    pub kind: HandlerLatestObjectKind,
+    /// Round of the commit whose execution produced this row; reads at commit
+    /// C treat rows above the horizon (C − K) as missing
+    pub produced_at: CommitRound,
+    /// `Some` iff the object was created as shared this epoch; doubles as the
+    /// created-shared flag for the shared-input checks.
+    pub initial_shared_version: Option<Version>,
+}
+
+impl IsNewer for HandlerLatestObject {
+    fn is_newer_than(&self, other: &Self) -> bool {
+        self.version > other.version
+    }
+}
+
+/// Marker for an object written by sync-ahead execution, restoring the
+/// pre-sync view for validation reads.
+///
+/// One record covers a whole chain of sync-ahead writes to the object
+/// (v -> v1 -> v2, ...): validation must treat every chain version uniformly
+/// as missing and only `base_version` as still latest, so no per-version
+/// data is needed. The record is consulted only while no handler-latest row
+/// exists for the object; once the handler reaches any commit touching it,
+/// the handler-latest row takes precedence on every read, so a record that
+/// outlives parts of the chain never leaks a stale answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncAheadRecord {
+    /// The version that was latest before sync ran ahead - the first version
+    /// this epoch's sync-ahead chain consumed - and therefore the only
+    /// version validation may still treat as live. `None` when the chain
+    /// created the object itself, in which case every named version answers
+    /// missing.
+    pub base_version: Option<Version>,
+    /// The highest version the chain has created so far; extended as the
+    /// chain grows.
+    pub latest_created: Version,
+}
+
+/// One object write of a sync-ahead execution, as input to the sync-record
+/// upsert: `consumed` is the input version this write superseded (`None` when
+/// the execution created the object), `created` the version it produced
+/// (tombstone version for deletions and wraps).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SyncAheadWrite {
+    pub id: ObjectId,
+    pub consumed: Option<Version>,
+    pub created: Version,
+}
+
+/// Derives the handler-latest upserts for one executed transaction of the
+/// commit at `produced_at`: created / mutated / unwrapped objects become
+/// `Live` rows, deletions and wraps become tombstone rows.
+pub fn handler_latest_upserts(
+    effects: &TransactionEffects,
+    produced_at: CommitRound,
+) -> Vec<(ObjectId, HandlerLatestObject)> {
+    let changed = effects.all_changed_objects();
+    let mut rows = Vec::with_capacity(changed.len());
+    for (owned_ref, write_kind) in changed {
+        let initial_shared_version = match (write_kind, owned_ref.owner) {
+            // A shared object's creation row carries its initial shared
+            // version - the created-shared flag the shared-input checks read.
+            (WriteKind::Create, Owner::Shared(initial)) => Some(initial),
+            // Shared-object mutations write nothing: no check consults shared
+            // state beyond existence, creation, and deletion, and hot shared
+            // objects (the Clock) would churn the row every commit.
+            (_, Owner::Shared(_)) => continue,
+            _ => None,
+        };
+        rows.push((
+            owned_ref.reference.object_id,
+            HandlerLatestObject {
+                version: owned_ref.reference.version,
+                digest: owned_ref.reference.digest,
+                kind: HandlerLatestObjectKind::Live,
+                produced_at,
+                initial_shared_version,
+            },
+        ));
+    }
+    let deleted = chain(effects.deleted(), effects.unwrapped_then_deleted())
+        .map(|reference| (reference, HandlerLatestObjectKind::Deleted));
+    let wrapped = effects
+        .wrapped()
+        .into_iter()
+        .map(|reference| (reference, HandlerLatestObjectKind::Wrapped));
+    for (reference, kind) in deleted.chain(wrapped) {
+        rows.push((
+            reference.object_id,
+            HandlerLatestObject {
+                version: reference.version,
+                digest: reference.digest,
+                kind,
+                produced_at,
+                initial_shared_version: None,
+            },
+        ));
+    }
+    rows
+}
+
+/// Derives the sync-ahead record writes for one sync-executed transaction:
+/// one write per object the execution wrote. `old_metadata` is the
+/// transaction's [`TransactionEffectsAPI::old_object_metadata`], passed in so
+/// the caller computes it once for this and
+/// [`consumed_input_keys_to_shelter`]. Shared-object mutations are skipped,
+/// mirroring the handler-latest churn rule; shared creations and deletions
+/// are included (a sync-ahead shared deletion must stay invisible to
+/// validation, which the record's restored pre-sync existence provides).
+pub fn sync_ahead_writes(
+    effects: &TransactionEffects,
+    old_metadata: &[OwnedObjectReference],
+) -> Vec<SyncAheadWrite> {
+    let old_versions: BTreeMap<ObjectId, Version> = old_metadata
+        .iter()
+        .map(|owned_ref| (owned_ref.reference.object_id, owned_ref.reference.version))
+        .collect();
+    let changed = effects.all_changed_objects();
+    let mut writes = Vec::with_capacity(changed.len());
+    for (owned_ref, write_kind) in changed {
+        let id = owned_ref.reference.object_id;
+        let consumed = match (write_kind, owned_ref.owner) {
+            // Creations restore nothing. Unwraps restore nothing either: the
+            // object had no live version before this chain ran, no matter
+            // when the wrap happened - and if this same chain wrapped it, a
+            // record carrying the pre-wrap version already exists and the
+            // upsert keeps it.
+            (WriteKind::Create | WriteKind::Unwrap, _) => None,
+            (WriteKind::Mutate, Owner::Shared(_)) => continue,
+            (WriteKind::Mutate, _) => old_versions.get(&id).copied(),
+        };
+        writes.push(SyncAheadWrite {
+            id,
+            consumed,
+            created: owned_ref.reference.version,
+        });
+    }
+    for reference in effects.unwrapped_then_deleted() {
+        writes.push(SyncAheadWrite {
+            id: reference.object_id,
+            consumed: None,
+            created: reference.version,
+        });
+    }
+    for reference in chain(effects.deleted(), effects.wrapped()) {
+        let id = reference.object_id;
+        writes.push(SyncAheadWrite {
+            id,
+            consumed: old_versions.get(&id).copied(),
+            created: reference.version,
+        });
+    }
+    writes
+}
+
+/// The input versions a transaction consumed that shelter rows must cover:
+/// address-owned versions, plus object-owned children conservatively (pending
+/// the deferred receiving-objects design). Shared inputs are existence-only
+/// and immutables are never superseded, so neither is sheltered.
+pub fn consumed_input_keys_to_shelter(old_metadata: &[OwnedObjectReference]) -> Vec<ObjectKey> {
+    old_metadata
+        .iter()
+        .filter(|owned_ref| matches!(owned_ref.owner, Owner::Address(_) | Owner::Object(_)))
+        .map(|owned_ref| ObjectKey::from(&owned_ref.reference))
+        .collect()
+}
+
+/// In-memory side of the bookkeeping plus every operation composing it with
+/// the durable tables. Overlays hold entries of commits whose rows are not
+/// yet durable; an entry leaves only after the corresponding table row is
+/// durable, and the read paths check the overlay first, so the transient
+/// both-present state is harmless.
+pub struct HandlerObjectState {
+    /// Digest → producing commit round for every kept transaction of commits
+    /// the handler has processed but whose executions have not all completed.
+    /// The execution hook consults it: hit → handler-latest upsert; miss →
+    /// sync-ahead execution. Never persisted: replay after restart re-runs
+    /// `assign_commit_to_transactions` before any (re-)execution can ask, and
+    /// commits below the durable resume point never consult it again.
+    commit_round_by_digest: DashMap<TransactionDigest, CommitRound>,
+    /// The digests assigned per round, so a fully executed commit can drop
+    /// its map entries.
+    digests_by_commit: Mutex<BTreeMap<CommitRound, Vec<TransactionDigest>>>,
+
+    handler_latest_overlay: RwLock<BTreeMap<ObjectId, HandlerLatestObject>>,
+    sync_ahead_overlay: RwLock<BTreeMap<ObjectId, SyncAheadRecord>>,
+    sheltered_overlay: RwLock<BTreeMap<ObjectKey, Arc<Object>>>,
+
+    /// Sync-ahead records the handler has caught up past, pending deletion
+    /// from the durable table; drained into the next flush batch.
+    sync_record_deletions: Mutex<BTreeSet<ObjectId>>,
+    /// Sync-ahead records currently alive (created and not yet queued for
+    /// deletion), so the per-commit cleanup can skip its table lookups
+    /// entirely in normal operation, when no record exists. Increments and
+    /// deletion-queue insertions pair exactly: a record recreated while its
+    /// deletion is queued cancels the deletion and counts as a fresh record.
+    live_sync_records: AtomicU64,
+
+    /// Read-through cache over the durable handler-latest table, so the cold
+    /// path of the hot per-input lookup is usually served without a table
+    /// read. Holds present rows only (absence could go stale the moment a
+    /// flush lands); refreshed write-through by `evict_flushed_commit_rows`,
+    /// with the ticket protocol rejecting stale inserts from readers racing
+    /// a flush. The other two tables get no cache: they are consulted only
+    /// after a handler-latest miss and are empty in normal operation, where
+    /// a table miss is a cheap bloom-filter negative.
+    handler_latest_cache: MonotonicCache<ObjectId, HandlerLatestObject>,
+}
+
+impl HandlerObjectState {
+    pub fn new(tables: &AuthorityEpochTables) -> Self {
+        // Nonzero only when reopening mid-epoch with sync-ahead records on
+        // disk; counting them keeps the cleanup short-circuit sound across a
+        // restart.
+        let live_sync_records = tables
+            .sync_ahead_records
+            .safe_iter()
+            .try_fold(0u64, |count, entry| entry.map(|_| count + 1))
+            .expect("AuthorityEpochTables should contain valid sync-ahead records");
+        Self {
+            commit_round_by_digest: DashMap::with_shard_amount(2048),
+            digests_by_commit: Mutex::new(BTreeMap::new()),
+            handler_latest_overlay: RwLock::new(BTreeMap::new()),
+            sync_ahead_overlay: RwLock::new(BTreeMap::new()),
+            sheltered_overlay: RwLock::new(BTreeMap::new()),
+            sync_record_deletions: Mutex::new(BTreeSet::new()),
+            live_sync_records: AtomicU64::new(live_sync_records),
+            handler_latest_cache: MonotonicCache::new(randomize_cache_capacity_in_tests(100_000)),
+        }
+    }
+
+    /// Records the kept transactions of commit `round`, before any of them
+    /// can be scheduled for execution.
+    pub fn assign_commit(&self, round: CommitRound, digests: Vec<TransactionDigest>) {
+        for digest in &digests {
+            self.commit_round_by_digest.insert(*digest, round);
+        }
+        self.digests_by_commit.lock().insert(round, digests);
+    }
+
+    /// The commit round that kept this transaction, if the handler has
+    /// processed that commit and it is not fully executed yet.
+    pub fn commit_round_of(&self, digest: &TransactionDigest) -> Option<CommitRound> {
+        self.commit_round_by_digest.get(digest).map(|round| *round)
+    }
+
+    /// Drops the digest → round entries of a fully executed commit, keeping
+    /// the map bounded.
+    pub fn drop_commit_assignments(&self, round: CommitRound) {
+        if let Some(digests) = self.digests_by_commit.lock().remove(&round) {
+            for digest in digests {
+                self.commit_round_by_digest.remove(&digest);
+            }
+        }
+    }
+
+    /// Records one executed transaction's object writes. Must be called by
+    /// the execution hook before the outputs become readable, so no object is
+    /// ever readable without its bookkeeping row. A transaction of a commit
+    /// the handler has processed upserts handler-latest rows; a transaction
+    /// only state sync knows yet writes sync-ahead records for every object
+    /// it wrote and shelters the bytes of the owned input versions it
+    /// consumed.
+    ///
+    /// `loaded_input_objects` must contain every consumed owned input at its
+    /// consumed version - including dynamic-field children and received
+    /// objects, which are not part of the declared input objects; a missing
+    /// one cannot be sheltered against pruning and is reported through
+    /// `debug_fatal`.
+    pub fn record_executed_transaction(
+        &self,
+        tables: &AuthorityEpochTables,
+        effects: &TransactionEffects,
+        loaded_input_objects: &[Object],
+    ) -> IotaResult {
+        if let Some(round) = self.commit_round_of(effects.transaction_digest()) {
+            self.upsert_handler_latest_rows(tables, &handler_latest_upserts(effects, round))
+        } else {
+            let old_metadata = effects.old_object_metadata();
+            self.upsert_sync_ahead_writes(tables, sync_ahead_writes(effects, &old_metadata))?;
+            self.shelter_consumed_inputs(
+                consumed_input_keys_to_shelter(&old_metadata),
+                loaded_input_objects,
+                effects.transaction_digest(),
+            );
+            Ok(())
+        }
+    }
+
+    /// Marks commit `round` fully executed: applies the commit's
+    /// handler-latest upserts (covering executions that raced the map
+    /// registration), removes sync-ahead records whose chains the handler has
+    /// now caught up past, and drops the commit's digest → round map entries.
+    ///
+    /// Sheltered bytes are deliberately not evicted here: their eviction keys
+    /// off the *flushed* frontier, because a crash before this commit's
+    /// output flushes replays and re-validates it, and those reads may still
+    /// need the bytes for versions the store has already pruned.
+    pub fn record_commit_fully_executed(
+        &self,
+        tables: &AuthorityEpochTables,
+        round: CommitRound,
+        upserts: &[(ObjectId, HandlerLatestObject)],
+    ) -> IotaResult {
+        // The upserts must be visible to readers before the sync records are
+        // removed: a validation read that finds neither concludes the object
+        // is untouched this epoch and consults epoch-start state.
+        self.upsert_handler_latest_rows(tables, upserts)?;
+        self.remove_passed_sync_records(tables, upserts)?;
+        self.drop_commit_assignments(round);
+        Ok(())
+    }
+
+    /// The latest state of `id` as of the handler frontier, from the overlay
+    /// or the durable table.
+    ///
+    /// Returns the row unconditionally; a caller validating at a commit round
+    /// must apply the reading condition itself (`produced_at` above its
+    /// horizon answers missing). Writers and cleanup need the unfiltered
+    /// frontier row, so no horizon is applied here.
+    pub fn handler_latest(
+        &self,
+        tables: &AuthorityEpochTables,
+        id: &ObjectId,
+    ) -> IotaResult<Option<HandlerLatestObject>> {
+        // The ticket snapshots this object's cache generation before any
+        // read. The cache fill below succeeds only if the generation is
+        // still the same; a flush that caches a newer row in the meantime
+        // (`Ticket::Write` in `evict_flushed_commit_rows`) bumps it, and the
+        // fill is discarded - the row read from the table here would be
+        // older than what the flush cached, and must not replace it.
+        let ticket = self.handler_latest_cache.get_ticket_for_read(id);
+        if let Some(row) = self.handler_latest_overlay.read().get(id) {
+            return Ok(Some(*row));
+        }
+        if let Some(entry) = self.handler_latest_cache.get(id) {
+            return Ok(Some(*entry.lock()));
+        }
+        let row = tables.handler_latest_objects.get(id)?;
+        if let Some(row) = row {
+            self.handler_latest_cache.insert(id, row, ticket).ok();
+        }
+        Ok(row)
+    }
+
+    /// The sync-ahead record for `id`, from the overlay or the durable table.
+    pub fn sync_record(
+        &self,
+        tables: &AuthorityEpochTables,
+        id: &ObjectId,
+    ) -> IotaResult<Option<SyncAheadRecord>> {
+        if let Some(record) = self.sync_ahead_overlay.read().get(id) {
+            return Ok(Some(*record));
+        }
+        Ok(tables.sync_ahead_records.get(id)?)
+    }
+
+    /// The sheltered bytes of a consumed input version, from the overlay or
+    /// the durable table.
+    pub fn sheltered_object(
+        &self,
+        tables: &AuthorityEpochTables,
+        key: &ObjectKey,
+    ) -> IotaResult<Option<Arc<Object>>> {
+        if let Some(object) = self.sheltered_overlay.read().get(key) {
+            return Ok(Some(object.clone()));
+        }
+        Ok(tables.sheltered_objects.get(key)?.map(Arc::new))
+    }
+
+    /// Stages a commit's handler-latest rows into `batch` - the quarantine
+    /// flush of the commit's own output, atomic with `last_consensus_stats` -
+    /// together with every queued sync-record deletion. The deletions must
+    /// ride this batch and no other: a deleted record's reads are answered by
+    /// handler-latest rows, so a deletion that became durable without them
+    /// (say, through the checkpoint executor's batch) would, after a crash,
+    /// leave reads falling through to the epoch-start rule against sync-ahead
+    /// store state. After the batch is durably written - never before - pass
+    /// the same rows to [`Self::evict_flushed_commit_rows`].
+    ///
+    /// These writes carry no version guard: the caller must flush commits in
+    /// commit order, one flush at a time (the quarantine flush does), or an
+    /// older row could overwrite a newer durable one.
+    pub fn write_commit_rows_to_batch(
+        &self,
+        tables: &AuthorityEpochTables,
+        batch: &mut DBBatch,
+        handler_rows: &[(ObjectId, HandlerLatestObject)],
+    ) -> IotaResult {
+        batch.insert_batch(
+            &tables.handler_latest_objects,
+            handler_rows.iter().map(|(id, row)| (id, row)),
+        )?;
+        // A deletion lost to a batch that never commits is re-queued when the
+        // commit replays.
+        let deletions = std::mem::take(&mut *self.sync_record_deletions.lock());
+        batch.delete_batch(&tables.sync_ahead_records, deletions)?;
+        Ok(())
+    }
+
+    /// Evicts a commit's handler-latest overlay entries once their rows are
+    /// durable. The cache is refreshed write-through before each entry is
+    /// removed, so a concurrent reader never observes a row absent from both;
+    /// an entry upserted again since the flush (a newer, still-unflushed row)
+    /// is kept.
+    pub fn evict_flushed_commit_rows(&self, handler_rows: &[(ObjectId, HandlerLatestObject)]) {
+        let mut overlay = self.handler_latest_overlay.write();
+        for (id, row) in handler_rows {
+            self.handler_latest_cache
+                .insert(id, *row, Ticket::Write)
+                .ok();
+            if overlay.get(id) == Some(row) {
+                overlay.remove(id);
+            }
+        }
+    }
+
+    /// Stages a sync-executed checkpoint's records and sheltered bytes into
+    /// `batch` - the checkpoint executor's auxiliary batch, durable before
+    /// the executed-checkpoint watermark bump that lets the pruner delete the
+    /// consumed versions' perpetual rows. After the batch is durably written
+    /// (never before), pass the same rows to
+    /// [`Self::evict_flushed_sync_ahead_rows`].
+    ///
+    /// These writes carry no version guard: the caller must flush checkpoints
+    /// in order, one at a time (the checkpoint executor does), or an older
+    /// record could overwrite a newer durable one.
+    pub fn write_sync_ahead_rows_to_batch(
+        &self,
+        tables: &AuthorityEpochTables,
+        batch: &mut DBBatch,
+        sync_rows: &[(ObjectId, SyncAheadRecord)],
+        shelter_rows: &[(ObjectKey, Arc<Object>)],
+    ) -> IotaResult {
+        batch.insert_batch(
+            &tables.sync_ahead_records,
+            sync_rows.iter().map(|(id, record)| (id, record)),
+        )?;
+        batch.insert_batch(
+            &tables.sheltered_objects,
+            shelter_rows
+                .iter()
+                .map(|(key, object)| (key, object.as_ref())),
+        )?;
+        Ok(())
+    }
+
+    /// Evicts sync-ahead overlay entries once their rows are durable. Must
+    /// cover the checkpoint's full derived row set - including keys the write
+    /// skipped as already present - because a replay after a crash re-inserts
+    /// overlay entries for rows that are already durable, and this recurring
+    /// eviction is what clears them. An entry extended since the flush is
+    /// kept; shelter rows are immutable per key, so no such check is needed
+    /// there.
+    pub fn evict_flushed_sync_ahead_rows(
+        &self,
+        sync_rows: &[(ObjectId, SyncAheadRecord)],
+        shelter_rows: &[(ObjectKey, Arc<Object>)],
+    ) {
+        {
+            let mut overlay = self.sync_ahead_overlay.write();
+            for (id, record) in sync_rows {
+                if overlay.get(id) == Some(record) {
+                    overlay.remove(id);
+                }
+            }
+        }
+        let mut overlay = self.sheltered_overlay.write();
+        for (key, _) in shelter_rows {
+            overlay.remove(key);
+        }
+    }
+
+    /// The number of entries in the (handler-latest, sync-ahead, sheltered)
+    /// overlays, for asserting eviction behavior.
+    #[cfg(test)]
+    pub fn overlay_lens_for_testing(&self) -> (usize, usize, usize) {
+        (
+            self.handler_latest_overlay.read().len(),
+            self.sync_ahead_overlay.read().len(),
+            self.sheltered_overlay.read().len(),
+        )
+    }
+
+    fn upsert_handler_latest_rows(
+        &self,
+        tables: &AuthorityEpochTables,
+        rows: &[(ObjectId, HandlerLatestObject)],
+    ) -> IotaResult {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let mut overlay = self.handler_latest_overlay.write();
+        for (id, row) in rows {
+            match overlay.get(id) {
+                // The writers racing on one id within a commit all write the
+                // same value; across commits a later commit's row always has
+                // a higher version, so the guard makes the row a monotone
+                // function of handler progress.
+                Some(current) => {
+                    if row.version >= current.version {
+                        overlay.insert(*id, *row);
+                    }
+                }
+                None => {
+                    // Compare against the durable row: watchers can fire out
+                    // of commit order, so once the overlay entry is evicted
+                    // this is the only guard keeping an older row from
+                    // shadowing the newer durable one through the
+                    // overlay-first read; strict `>` also keeps a watcher
+                    // firing after its commit flushed from re-adding a row
+                    // nothing would ever evict.
+                    let durable = tables.handler_latest_objects.get(id)?;
+                    if durable.is_none_or(|durable| row.version > durable.version) {
+                        overlay.insert(*id, *row);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn upsert_sync_ahead_writes(
+        &self,
+        tables: &AuthorityEpochTables,
+        writes: Vec<SyncAheadWrite>,
+    ) -> IotaResult {
+        if writes.is_empty() {
+            return Ok(());
+        }
+        let mut overlay = self.sync_ahead_overlay.write();
+        let mut deletions = self.sync_record_deletions.lock();
+        for write in writes {
+            let current = match overlay.get(&write.id) {
+                Some(record) => Some(*record),
+                // A record with a queued deletion is logically gone (the
+                // handler caught up past its chain) but stays in the table
+                // until the queue drains into a commit flush; it must be
+                // invisible here, or a new chain would extend the dead record
+                // and inherit its stale `base_version`.
+                None if deletions.contains(&write.id) => None,
+                None => tables.sync_ahead_records.get(&write.id)?,
+            };
+            // Only an extension of the chain updates the record
+            // (re-executions after a restart replay the same writes).
+            if current.is_none_or(|record| write.created > record.latest_created) {
+                if current.is_none() {
+                    // Cancel any queued deletion of the dead record: it
+                    // drains into a later flush batch, which must not destroy
+                    // the new record's durable row.
+                    deletions.remove(&write.id);
+
+                    self.live_sync_records.fetch_add(1, Ordering::Relaxed);
+                }
+                let base_version = match current {
+                    // First write of the chain: what it consumed is what was
+                    // latest before the chain started (`None` when it created
+                    // the object).
+                    None => write.consumed,
+                    // The chain already has a record: keep its
+                    // `base_version` and ignore `write.consumed` - later
+                    // writes consume the chain's own outputs, which exist
+                    // only on validators that synced ahead. In particular, a
+                    // chain that created the object and then mutates it must
+                    // keep `None`, or validation here would answer keep for a
+                    // version every other validator answers missing.
+                    Some(record) => record.base_version,
+                };
+                overlay.insert(
+                    write.id,
+                    SyncAheadRecord {
+                        base_version,
+                        latest_created: write.created,
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn shelter_consumed_inputs(
+        &self,
+        keys: Vec<ObjectKey>,
+        loaded_input_objects: &[Object],
+        tx_digest: &TransactionDigest,
+    ) {
+        if keys.is_empty() {
+            return;
+        }
+        let mut needed: BTreeSet<ObjectKey> = keys.into_iter().collect();
+        let mut overlay = self.sheltered_overlay.write();
+        for object in loaded_input_objects {
+            let key = ObjectKey(object.id(), object.version());
+            // A replay after a crash may re-insert rows that are already
+            // durable; that is fine - the checkpoint executor's persist step
+            // re-runs on the same replay and evicts them again, and the
+            // bytes are identical either way.
+            if needed.remove(&key) {
+                overlay.insert(key, Arc::new(object.clone()));
+            }
+        }
+        for key in needed {
+            debug_fatal!(
+                "input {key:?} consumed by sync-executed transaction {tx_digest} missing from \
+                 the loaded inputs; its bytes cannot be sheltered against pruning"
+            );
+        }
+    }
+
+    fn remove_passed_sync_records(
+        &self,
+        tables: &AuthorityEpochTables,
+        upserts: &[(ObjectId, HandlerLatestObject)],
+    ) -> IotaResult {
+        // Normal operation: no sync-ahead record exists anywhere, so the
+        // per-commit cleanup costs one atomic load instead of a table lookup
+        // per written object.
+        if self.live_sync_records.load(Ordering::Relaxed) == 0 {
+            return Ok(());
+        }
+        let mut overlay = self.sync_ahead_overlay.write();
+        let mut deletions = self.sync_record_deletions.lock();
+        for (id, row) in upserts {
+            let record = match overlay.get(id) {
+                Some(record) => Some(*record),
+                None => tables.sync_ahead_records.get(id)?,
+            };
+            // The handler has caught up past the whole sync-ahead chain; the
+            // handler-latest row (already visible) now answers every read the
+            // record used to.
+            if record.is_some_and(|record| record.latest_created <= row.version) {
+                overlay.remove(id);
+                // Queue the durable deletion even when the record was found
+                // only in the overlay: an extended record leaves its older
+                // durable row behind, and the checkpoint executor's persist
+                // step (which derives rows from effects, not the overlay) can
+                // still write this record after the removal. Deleting a key
+                // that never became durable is a no-op.
+                if deletions.insert(*id) {
+                    self.live_sync_records.fetch_sub(1, Ordering::Relaxed);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_sdk_types::{Address, ObjectReference, SenderSignedTransaction};
+    use iota_test_transaction_builder::TestTransactionBuilder;
+    use iota_types::{effects::TestEffectsBuilder, transaction::TransactionAPI};
+
+    use super::*;
+
+    fn owned_inputs_tx(gas_version: u64) -> SenderSignedTransaction {
+        let tx_data = TestTransactionBuilder::new(
+            Address::ZERO,
+            ObjectReference::new(
+                ObjectId::random(),
+                Version::from_u64(gas_version),
+                ObjectDigest::random(),
+            ),
+            0,
+        )
+        .transfer_iota(None, Address::ZERO)
+        .build();
+        SenderSignedTransaction::new(tx_data, vec![])
+    }
+
+    struct EffectsFixture {
+        effects: TransactionEffects,
+        created_owned: ObjectId,
+        created_shared: ObjectId,
+        mutated_owned: ObjectId,
+        deleted: ObjectId,
+        wrapped: ObjectId,
+        unwrapped: ObjectId,
+        gas: ObjectId,
+    }
+
+    const CREATED_SHARED_INITIAL_VERSION: u64 = 42;
+
+    fn effects_fixture() -> EffectsFixture {
+        let transaction = owned_inputs_tx(1);
+        let gas = transaction.transaction().gas()[0].object_id;
+        let created_owned = ObjectId::random();
+        let created_shared = ObjectId::random();
+        let mutated_owned = ObjectId::random();
+        let deleted = ObjectId::random();
+        let wrapped = ObjectId::random();
+        let unwrapped = ObjectId::random();
+        let effects = TestEffectsBuilder::new(&transaction)
+            .with_created_objects([
+                (created_owned, Owner::Address(Address::ZERO)),
+                (
+                    created_shared,
+                    Owner::Shared(Version::from_u64(CREATED_SHARED_INITIAL_VERSION)),
+                ),
+            ])
+            .with_mutated_objects([(
+                mutated_owned,
+                Version::from_u64(5),
+                Owner::Address(Address::ZERO),
+            )])
+            .with_deleted_objects([(deleted, Version::from_u64(3))])
+            .with_wrapped_objects([(wrapped, Version::from_u64(2))])
+            .with_unwrapped_objects([(unwrapped, Owner::Address(Address::ZERO))])
+            .build();
+        EffectsFixture {
+            effects,
+            created_owned,
+            created_shared,
+            mutated_owned,
+            deleted,
+            wrapped,
+            unwrapped,
+            gas,
+        }
+    }
+
+    #[test]
+    fn handler_latest_upserts_map_every_write_kind() {
+        let fixture = effects_fixture();
+        let lamport = fixture.effects.lamport_version();
+        let round: CommitRound = 9;
+        let rows: BTreeMap<ObjectId, HandlerLatestObject> =
+            handler_latest_upserts(&fixture.effects, round)
+                .into_iter()
+                .collect();
+
+        let created_owned = &rows[&fixture.created_owned];
+        assert_eq!(created_owned.kind, HandlerLatestObjectKind::Live);
+        assert_eq!(created_owned.version, lamport);
+        assert_eq!(created_owned.produced_at, round);
+        assert_eq!(created_owned.initial_shared_version, None);
+
+        let created_shared = &rows[&fixture.created_shared];
+        assert_eq!(created_shared.kind, HandlerLatestObjectKind::Live);
+        assert_eq!(
+            created_shared.initial_shared_version,
+            Some(Version::from_u64(CREATED_SHARED_INITIAL_VERSION))
+        );
+
+        assert_eq!(
+            rows[&fixture.mutated_owned].kind,
+            HandlerLatestObjectKind::Live
+        );
+        assert_eq!(rows[&fixture.mutated_owned].version, lamport);
+        assert_eq!(rows[&fixture.gas].kind, HandlerLatestObjectKind::Live);
+        assert_eq!(rows[&fixture.unwrapped].kind, HandlerLatestObjectKind::Live);
+
+        assert_eq!(
+            rows[&fixture.deleted].kind,
+            HandlerLatestObjectKind::Deleted
+        );
+        assert_eq!(rows[&fixture.deleted].version, lamport);
+        assert_eq!(
+            rows[&fixture.wrapped].kind,
+            HandlerLatestObjectKind::Wrapped
+        );
+        assert_eq!(rows[&fixture.wrapped].version, lamport);
+
+        assert_eq!(rows.len(), 7);
+    }
+
+    #[test]
+    fn sync_ahead_writes_carry_consumed_versions() {
+        let fixture = effects_fixture();
+        let lamport = fixture.effects.lamport_version();
+        let old_metadata = fixture.effects.old_object_metadata();
+        let writes: BTreeMap<ObjectId, SyncAheadWrite> =
+            sync_ahead_writes(&fixture.effects, &old_metadata)
+                .into_iter()
+                .map(|write| (write.id, write))
+                .collect();
+
+        assert_eq!(writes[&fixture.created_owned].consumed, None);
+        assert_eq!(writes[&fixture.created_shared].consumed, None);
+        assert_eq!(writes[&fixture.unwrapped].consumed, None);
+        assert_eq!(
+            writes[&fixture.mutated_owned].consumed,
+            Some(Version::from_u64(5))
+        );
+        assert_eq!(
+            writes[&fixture.deleted].consumed,
+            Some(Version::from_u64(3))
+        );
+        assert_eq!(
+            writes[&fixture.wrapped].consumed,
+            Some(Version::from_u64(2))
+        );
+        assert_eq!(writes[&fixture.gas].consumed, Some(Version::from_u64(1)));
+        for write in writes.values() {
+            assert_eq!(write.created, lamport);
+        }
+        assert_eq!(writes.len(), 7);
+    }
+
+    #[test]
+    fn shelter_keys_cover_consumed_owned_inputs() {
+        let fixture = effects_fixture();
+        let keys = consumed_input_keys_to_shelter(&fixture.effects.old_object_metadata());
+        let expected = [
+            ObjectKey(fixture.mutated_owned, Version::from_u64(5)),
+            ObjectKey(fixture.deleted, Version::from_u64(3)),
+            ObjectKey(fixture.wrapped, Version::from_u64(2)),
+            ObjectKey(fixture.gas, Version::from_u64(1)),
+        ];
+        assert_eq!(keys.len(), expected.len());
+        for key in expected {
+            assert!(keys.contains(&key), "missing shelter key {key:?}");
+        }
+    }
+
+    #[test]
+    fn shared_input_mutation_writes_nothing() {
+        use iota_sdk_types::SharedObjectReference;
+        use iota_types::{
+            programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::CallArg,
+        };
+
+        let shared_id = ObjectId::random();
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .obj(CallArg::Shared(SharedObjectReference::new(
+                shared_id,
+                Version::from_u64(7),
+                true,
+            )))
+            .unwrap();
+        let tx_data = TestTransactionBuilder::new(
+            Address::ZERO,
+            ObjectReference::new(
+                ObjectId::random(),
+                Version::from_u64(1),
+                ObjectDigest::random(),
+            ),
+            0,
+        )
+        .programmable(builder.finish())
+        .build();
+        let transaction = SenderSignedTransaction::new(tx_data, vec![]);
+        let effects = TestEffectsBuilder::new(&transaction)
+            .with_shared_input_versions(BTreeMap::from([(shared_id, Version::from_u64(20))]))
+            .build();
+        let old_metadata = effects.old_object_metadata();
+
+        let rows = handler_latest_upserts(&effects, 4);
+        assert!(rows.iter().all(|(id, _)| *id != shared_id));
+        let writes = sync_ahead_writes(&effects, &old_metadata);
+        assert!(writes.iter().all(|write| write.id != shared_id));
+        let keys = consumed_input_keys_to_shelter(&old_metadata);
+        assert!(keys.iter().all(|key| key.0 != shared_id));
+    }
+
+    #[test]
+    fn commit_round_map_assign_and_drop() {
+        let state = HandlerObjectState {
+            commit_round_by_digest: DashMap::with_shard_amount(2048),
+            digests_by_commit: Mutex::new(BTreeMap::new()),
+            handler_latest_overlay: RwLock::new(BTreeMap::new()),
+            sync_ahead_overlay: RwLock::new(BTreeMap::new()),
+            sheltered_overlay: RwLock::new(BTreeMap::new()),
+            sync_record_deletions: Mutex::new(BTreeSet::new()),
+            live_sync_records: AtomicU64::new(0),
+            handler_latest_cache: MonotonicCache::new(100),
+        };
+        let digest_a = TransactionDigest::random();
+        let digest_b = TransactionDigest::random();
+        state.assign_commit(3, vec![digest_a]);
+        state.assign_commit(4, vec![digest_b]);
+        assert_eq!(state.commit_round_of(&digest_a), Some(3));
+        assert_eq!(state.commit_round_of(&digest_b), Some(4));
+        state.drop_commit_assignments(3);
+        assert_eq!(state.commit_round_of(&digest_a), None);
+        assert_eq!(state.commit_round_of(&digest_b), Some(4));
+    }
+}

--- a/crates/iota-core/src/authority/handler_object_state.rs
+++ b/crates/iota-core/src/authority/handler_object_state.rs
@@ -282,13 +282,13 @@ pub struct HandlerObjectState {
 
     /// Sync-ahead records the handler has caught up past, pending deletion
     /// from the durable table; drained into the next flush batch.
-    sync_record_deletions: Mutex<BTreeSet<ObjectId>>,
+    sync_ahead_record_deletions: Mutex<BTreeSet<ObjectId>>,
     /// Sync-ahead records currently alive (created and not yet queued for
     /// deletion), so the per-commit cleanup can skip its table lookups
     /// entirely in normal operation, when no record exists. Increments and
     /// deletion-queue insertions pair exactly: a record recreated while its
     /// deletion is queued cancels the deletion and counts as a fresh record.
-    live_sync_records: AtomicU64,
+    live_sync_ahead_records_count: AtomicU64,
 
     /// Read-through cache over the durable handler-latest table, so the cold
     /// path of the hot per-input lookup is usually served without a table
@@ -306,7 +306,7 @@ impl HandlerObjectState {
         // Nonzero only when reopening mid-epoch with sync-ahead records on
         // disk; counting them keeps the cleanup short-circuit sound across a
         // restart.
-        let live_sync_records = tables
+        let live_sync_ahead_records_count = tables
             .sync_ahead_records
             .safe_iter()
             .try_fold(0u64, |count, entry| entry.map(|_| count + 1))
@@ -317,8 +317,8 @@ impl HandlerObjectState {
             handler_latest_overlay: RwLock::new(BTreeMap::new()),
             sync_ahead_overlay: RwLock::new(BTreeMap::new()),
             sheltered_overlay: RwLock::new(BTreeMap::new()),
-            sync_record_deletions: Mutex::new(BTreeSet::new()),
-            live_sync_records: AtomicU64::new(live_sync_records),
+            sync_ahead_record_deletions: Mutex::new(BTreeSet::new()),
+            live_sync_ahead_records_count: AtomicU64::new(live_sync_ahead_records_count),
             handler_latest_cache: MonotonicCache::new(randomize_cache_capacity_in_tests(100_000)),
         }
     }
@@ -400,7 +400,7 @@ impl HandlerObjectState {
         // removed: a validation read that finds neither concludes the object
         // is untouched this epoch and consults epoch-start state.
         self.upsert_handler_latest_rows(tables, upserts)?;
-        self.remove_passed_sync_records(tables, upserts)?;
+        self.remove_handled_sync_ahead_records(tables, upserts)?;
         self.drop_commit_assignments(round);
         Ok(())
     }
@@ -438,7 +438,7 @@ impl HandlerObjectState {
     }
 
     /// The sync-ahead record for `id`, from the overlay or the durable table.
-    pub fn sync_record(
+    pub fn sync_ahead_record(
         &self,
         tables: &AuthorityEpochTables,
         id: &ObjectId,
@@ -487,7 +487,7 @@ impl HandlerObjectState {
         )?;
         // A deletion lost to a batch that never commits is re-queued when the
         // commit replays.
-        let deletions = std::mem::take(&mut *self.sync_record_deletions.lock());
+        let deletions = std::mem::take(&mut *self.sync_ahead_record_deletions.lock());
         batch.delete_batch(&tables.sync_ahead_records, deletions)?;
         Ok(())
     }
@@ -568,7 +568,7 @@ impl HandlerObjectState {
     /// The number of entries in the (handler-latest, sync-ahead, sheltered)
     /// overlays, for asserting eviction behavior.
     #[cfg(test)]
-    pub fn overlay_lens_for_testing(&self) -> (usize, usize, usize) {
+    pub fn overlay_sizes_for_testing(&self) -> (usize, usize, usize) {
         (
             self.handler_latest_overlay.read().len(),
             self.sync_ahead_overlay.read().len(),
@@ -623,7 +623,7 @@ impl HandlerObjectState {
             return Ok(());
         }
         let mut overlay = self.sync_ahead_overlay.write();
-        let mut deletions = self.sync_record_deletions.lock();
+        let mut deletions = self.sync_ahead_record_deletions.lock();
         for write in writes {
             let current = match overlay.get(&write.id) {
                 Some(record) => Some(*record),
@@ -644,7 +644,8 @@ impl HandlerObjectState {
                     // the new record's durable row.
                     deletions.remove(&write.id);
 
-                    self.live_sync_records.fetch_add(1, Ordering::Relaxed);
+                    self.live_sync_ahead_records_count
+                        .fetch_add(1, Ordering::Relaxed);
                 }
                 let base_version = match current {
                     // First write of the chain: what it consumed is what was
@@ -701,7 +702,7 @@ impl HandlerObjectState {
         }
     }
 
-    fn remove_passed_sync_records(
+    fn remove_handled_sync_ahead_records(
         &self,
         tables: &AuthorityEpochTables,
         upserts: &[(ObjectId, HandlerLatestObject)],
@@ -709,11 +710,11 @@ impl HandlerObjectState {
         // Normal operation: no sync-ahead record exists anywhere, so the
         // per-commit cleanup costs one atomic load instead of a table lookup
         // per written object.
-        if self.live_sync_records.load(Ordering::Relaxed) == 0 {
+        if self.live_sync_ahead_records_count.load(Ordering::Relaxed) == 0 {
             return Ok(());
         }
         let mut overlay = self.sync_ahead_overlay.write();
-        let mut deletions = self.sync_record_deletions.lock();
+        let mut deletions = self.sync_ahead_record_deletions.lock();
         for (id, row) in upserts {
             let record = match overlay.get(id) {
                 Some(record) => Some(*record),
@@ -731,7 +732,8 @@ impl HandlerObjectState {
                 // still write this record after the removal. Deleting a key
                 // that never became durable is a no-op.
                 if deletions.insert(*id) {
-                    self.live_sync_records.fetch_sub(1, Ordering::Relaxed);
+                    self.live_sync_ahead_records_count
+                        .fetch_sub(1, Ordering::Relaxed);
                 }
             }
         }
@@ -956,8 +958,8 @@ mod tests {
             handler_latest_overlay: RwLock::new(BTreeMap::new()),
             sync_ahead_overlay: RwLock::new(BTreeMap::new()),
             sheltered_overlay: RwLock::new(BTreeMap::new()),
-            sync_record_deletions: Mutex::new(BTreeSet::new()),
-            live_sync_records: AtomicU64::new(0),
+            sync_ahead_record_deletions: Mutex::new(BTreeSet::new()),
+            live_sync_ahead_records_count: AtomicU64::new(0),
             handler_latest_cache: MonotonicCache::new(100),
         };
         let digest_a = TransactionDigest::random();

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1816,3 +1816,361 @@ async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
     assert_eq!(asserted.load(Ordering::SeqCst), 1);
     assert_eq!(store.metrics.deny_rule_update_execution_failures.get(), 1);
 }
+
+// === P-COOL deterministic-validation bookkeeping (handler_object_state) ===
+
+mod handler_object_state_storage {
+    use std::sync::Arc;
+
+    use iota_sdk_types::{
+        Address, ObjectDigest, ObjectReference, Owner, SenderSignedTransaction, TransactionEffects,
+    };
+    use iota_test_transaction_builder::TestTransactionBuilder;
+    use iota_types::{
+        base_types::CommitRound,
+        effects::{TestEffectsBuilder, TransactionEffectsAPI},
+        object::Object,
+        storage::ObjectKey,
+        transaction::TransactionAPI,
+    };
+
+    use super::*;
+    use crate::authority::authority_per_epoch_store::handler_object_state::{
+        HandlerLatestObject, HandlerLatestObjectKind, SyncAheadRecord,
+    };
+
+    fn owned_object(id: ObjectId, version: u64) -> Object {
+        Object::with_id_owner_version_for_testing(
+            id,
+            Version::from_u64(version),
+            Owner::Address(Address::ZERO),
+        )
+    }
+
+    fn owned_inputs_tx(gas_version: u64) -> SenderSignedTransaction {
+        let tx_data = TestTransactionBuilder::new(
+            Address::ZERO,
+            ObjectReference::new(
+                ObjectId::random(),
+                Version::from_u64(gas_version),
+                ObjectDigest::random(),
+            ),
+            0,
+        )
+        .transfer_iota(None, Address::ZERO)
+        .build();
+        SenderSignedTransaction::new(tx_data, vec![])
+    }
+
+    /// A transaction consuming `(consumed, consumed_version)` plus its gas
+    /// coin, with the loaded inputs the execution hook would hold.
+    fn sync_executed_tx(
+        consumed: ObjectId,
+        consumed_version: u64,
+        gas_version: u64,
+    ) -> (TransactionEffects, Vec<Object>) {
+        let transaction = owned_inputs_tx(gas_version);
+        let gas = transaction.transaction().gas()[0].object_id;
+        let effects = TestEffectsBuilder::new(&transaction)
+            .with_mutated_objects([(
+                consumed,
+                Version::from_u64(consumed_version),
+                Owner::Address(Address::ZERO),
+            )])
+            .build();
+        let inputs = vec![
+            owned_object(consumed, consumed_version),
+            owned_object(gas, gas_version),
+        ];
+        (effects, inputs)
+    }
+
+    fn live_row(version: Version, produced_at: CommitRound) -> HandlerLatestObject {
+        HandlerLatestObject {
+            version,
+            digest: ObjectDigest::random(),
+            kind: HandlerLatestObjectKind::Live,
+            produced_at,
+            initial_shared_version: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_latest_upserts_are_monotone_across_overlay_and_table() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+        let state = epoch_store.handler_object_state_for_testing();
+        let id = ObjectId::random();
+
+        let v5 = live_row(Version::from_u64(5), 1);
+        epoch_store
+            .record_commit_fully_executed(1, &[(id, v5)])
+            .unwrap();
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
+
+        // An older row never overwrites a newer one.
+        epoch_store
+            .record_commit_fully_executed(0, &[(id, live_row(Version::from_u64(3), 0))])
+            .unwrap();
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
+
+        // Flushing moves the row out of the overlay without a read gap.
+        epoch_store
+            .flush_commit_rows_for_testing(vec![(id, v5)])
+            .unwrap();
+        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
+
+        // A watcher firing after its commit already flushed must not re-add
+        // the identical row to the overlay, or it would stay there forever.
+        epoch_store
+            .record_commit_fully_executed(1, &[(id, v5)])
+            .unwrap();
+        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+
+        // An even older row arriving after the flush (an out-of-order watcher
+        // of an earlier commit) must not shadow the durable row through the
+        // overlay-first read.
+        epoch_store
+            .record_commit_fully_executed(0, &[(id, live_row(Version::from_u64(2), 0))])
+            .unwrap();
+        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
+
+        // A later commit's row supersedes the flushed one through the overlay.
+        let v7 = live_row(Version::from_u64(7), 2);
+        epoch_store
+            .record_commit_fully_executed(2, &[(id, v7)])
+            .unwrap();
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v7));
+    }
+
+    #[tokio::test]
+    async fn map_miss_writes_sync_records_and_shelter_but_never_handler_latest() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+
+        let mutated = ObjectId::random();
+        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        let lamport = effects.lamport_version();
+
+        // The digest is not in the round map: this execution is state sync
+        // running ahead of the handler.
+        epoch_store
+            .record_executed_transaction(&effects, &loaded_inputs)
+            .unwrap();
+
+        assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), None);
+        assert_eq!(
+            epoch_store.sync_record(&mutated).unwrap(),
+            Some(SyncAheadRecord {
+                base_version: Some(Version::from_u64(5)),
+                latest_created: lamport,
+            })
+        );
+        let sheltered = epoch_store
+            .sheltered_object(&ObjectKey(mutated, Version::from_u64(5)))
+            .unwrap()
+            .expect("consumed input must be sheltered");
+        assert_eq!(sheltered.version(), Version::from_u64(5));
+
+        // A second sync-executed transaction consuming the chain's output
+        // extends the record without touching its previous version.
+        let (next_effects, next_inputs) = sync_executed_tx(mutated, lamport.as_u64(), 2);
+        epoch_store
+            .record_executed_transaction(&next_effects, &next_inputs)
+            .unwrap();
+        assert_eq!(
+            epoch_store.sync_record(&mutated).unwrap(),
+            Some(SyncAheadRecord {
+                base_version: Some(Version::from_u64(5)),
+                latest_created: next_effects.lamport_version(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_created_object_keeps_base_version_none_when_chain_extends() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+
+        // State sync creates the object ahead of the handler...
+        let created = ObjectId::random();
+        let create_tx = owned_inputs_tx(1);
+        let create_effects = TestEffectsBuilder::new(&create_tx)
+            .with_created_objects([(created, Owner::Address(Address::ZERO))])
+            .build();
+        let gas = create_tx.transaction().gas()[0].object_id;
+        epoch_store
+            .record_executed_transaction(&create_effects, &[owned_object(gas, 1)])
+            .unwrap();
+        let created_version = create_effects.lamport_version();
+        assert_eq!(
+            epoch_store.sync_record(&created).unwrap(),
+            Some(SyncAheadRecord {
+                base_version: None,
+                latest_created: created_version,
+            })
+        );
+
+        // ...then consumes its own creation. The record must keep
+        // `base_version: None`: the consumed version exists only on
+        // validators that synced ahead, so no named version may answer keep.
+        let (mutate_effects, mutate_inputs) =
+            sync_executed_tx(created, created_version.as_u64(), 2);
+        epoch_store
+            .record_executed_transaction(&mutate_effects, &mutate_inputs)
+            .unwrap();
+        assert_eq!(
+            epoch_store.sync_record(&created).unwrap(),
+            Some(SyncAheadRecord {
+                base_version: None,
+                latest_created: mutate_effects.lamport_version(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn recreated_sync_record_starts_fresh_and_survives_deletion_drain() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+
+        // A sync-ahead chain runs and its record becomes durable (the
+        // checkpoint executor's flush).
+        let mutated = ObjectId::random();
+        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        epoch_store
+            .record_executed_transaction(&effects, &loaded_inputs)
+            .unwrap();
+        let first_chain_head = effects.lamport_version();
+        let first_record = epoch_store.sync_record(&mutated).unwrap().unwrap();
+        epoch_store
+            .flush_sync_ahead_rows_for_testing(vec![(mutated, first_record)], vec![])
+            .unwrap();
+
+        // The handler catches up past the chain: the durable row lingers
+        // (shadowed by the handler-latest row) until its queued deletion
+        // drains.
+        epoch_store
+            .record_commit_fully_executed(8, &[(mutated, live_row(first_chain_head, 8))])
+            .unwrap();
+        assert_eq!(
+            epoch_store.sync_record(&mutated).unwrap(),
+            Some(first_record)
+        );
+
+        // A second chain starts before the deletion drains: it must get a
+        // fresh base (the handler-written version it consumed), not extend
+        // the dead record.
+        let (next_effects, next_inputs) = sync_executed_tx(mutated, first_chain_head.as_u64(), 2);
+        epoch_store
+            .record_executed_transaction(&next_effects, &next_inputs)
+            .unwrap();
+        let record = SyncAheadRecord {
+            base_version: Some(first_chain_head),
+            latest_created: next_effects.lamport_version(),
+        };
+        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), Some(record));
+
+        // The stale queued deletion was canceled: draining (a commit flush)
+        // after the new record becomes durable must not destroy it.
+        epoch_store
+            .flush_sync_ahead_rows_for_testing(vec![(mutated, record)], vec![])
+            .unwrap();
+        epoch_store.flush_commit_rows_for_testing(vec![]).unwrap();
+        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), Some(record));
+    }
+
+    #[tokio::test]
+    async fn map_hit_writes_handler_latest_only() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+
+        let mutated = ObjectId::random();
+        let (effects, _) = sync_executed_tx(mutated, 5, 1);
+
+        epoch_store.assign_commit_to_transactions(6, vec![*effects.transaction_digest()]);
+        epoch_store
+            .record_executed_transaction(&effects, &[])
+            .unwrap();
+
+        let row = epoch_store
+            .handler_latest(&mutated)
+            .unwrap()
+            .expect("handler-latest row must exist for a handler-known commit");
+        assert_eq!(row.produced_at, 6);
+        assert_eq!(row.version, effects.lamport_version());
+        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), None);
+        assert_eq!(
+            epoch_store
+                .sheltered_object(&ObjectKey(mutated, Version::from_u64(5)))
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn fully_executed_commit_cleans_sync_records_and_round_map() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+
+        // State sync executes a transaction ahead of the handler.
+        let mutated = ObjectId::random();
+        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        epoch_store
+            .record_executed_transaction(&effects, &loaded_inputs)
+            .unwrap();
+        assert!(epoch_store.sync_record(&mutated).unwrap().is_some());
+
+        // The handler catches up past the whole chain: the sync record goes,
+        // the handler-latest row answers instead.
+        let row = live_row(effects.lamport_version(), 8);
+        epoch_store
+            .record_commit_fully_executed(8, &[(mutated, row)])
+            .unwrap();
+        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), None);
+        assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), Some(row));
+    }
+
+    #[tokio::test]
+    async fn reads_survive_flush_of_sync_and_shelter_rows() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+        let state = epoch_store.handler_object_state_for_testing();
+
+        let mutated = ObjectId::random();
+        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        let gas = loaded_inputs[1].id();
+        epoch_store
+            .record_executed_transaction(&effects, &loaded_inputs)
+            .unwrap();
+
+        // Flush everything the sync execution wrote, then verify the reads
+        // are served from the durable tables with empty overlays.
+        let sync_rows: Vec<(ObjectId, SyncAheadRecord)> = [mutated, gas]
+            .iter()
+            .map(|id| (*id, epoch_store.sync_record(id).unwrap().unwrap()))
+            .collect();
+        let shelter_rows: Vec<(ObjectKey, Arc<Object>)> = [
+            ObjectKey(mutated, Version::from_u64(5)),
+            ObjectKey(gas, Version::from_u64(1)),
+        ]
+        .iter()
+        .map(|key| (*key, epoch_store.sheltered_object(key).unwrap().unwrap()))
+        .collect();
+        epoch_store
+            .flush_sync_ahead_rows_for_testing(sync_rows.clone(), shelter_rows.clone())
+            .unwrap();
+
+        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        for (id, record) in &sync_rows {
+            assert_eq!(epoch_store.sync_record(id).unwrap(), Some(*record));
+        }
+        for (key, object) in &shelter_rows {
+            assert_eq!(
+                epoch_store.sheltered_object(key).unwrap().as_deref(),
+                Some(object.as_ref())
+            );
+        }
+    }
+}

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1864,7 +1864,7 @@ mod handler_object_state_storage {
 
     /// A transaction consuming `(consumed, consumed_version)` plus its gas
     /// coin, with the loaded inputs the execution hook would hold.
-    fn sync_executed_tx(
+    fn executed_owned_tx_effects(
         consumed: ObjectId,
         consumed_version: u64,
         gas_version: u64,
@@ -1885,7 +1885,7 @@ mod handler_object_state_storage {
         (effects, inputs)
     }
 
-    fn live_row(version: Version, produced_at: CommitRound) -> HandlerLatestObject {
+    fn generate_live_entry(version: Version, produced_at: CommitRound) -> HandlerLatestObject {
         HandlerLatestObject {
             version,
             digest: ObjectDigest::random(),
@@ -1902,7 +1902,7 @@ mod handler_object_state_storage {
         let state = epoch_store.handler_object_state_for_testing();
         let id = ObjectId::random();
 
-        let v5 = live_row(Version::from_u64(5), 1);
+        let v5 = generate_live_entry(Version::from_u64(5), 1);
         epoch_store
             .record_commit_fully_executed(1, &[(id, v5)])
             .unwrap();
@@ -1910,7 +1910,7 @@ mod handler_object_state_storage {
 
         // An older row never overwrites a newer one.
         epoch_store
-            .record_commit_fully_executed(0, &[(id, live_row(Version::from_u64(3), 0))])
+            .record_commit_fully_executed(0, &[(id, generate_live_entry(Version::from_u64(3), 0))])
             .unwrap();
         assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
 
@@ -1918,7 +1918,7 @@ mod handler_object_state_storage {
         epoch_store
             .flush_commit_rows_for_testing(vec![(id, v5)])
             .unwrap();
-        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(state.overlay_sizes_for_testing(), (0, 0, 0));
         assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
 
         // A watcher firing after its commit already flushed must not re-add
@@ -1926,19 +1926,19 @@ mod handler_object_state_storage {
         epoch_store
             .record_commit_fully_executed(1, &[(id, v5)])
             .unwrap();
-        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(state.overlay_sizes_for_testing(), (0, 0, 0));
 
         // An even older row arriving after the flush (an out-of-order watcher
         // of an earlier commit) must not shadow the durable row through the
         // overlay-first read.
         epoch_store
-            .record_commit_fully_executed(0, &[(id, live_row(Version::from_u64(2), 0))])
+            .record_commit_fully_executed(0, &[(id, generate_live_entry(Version::from_u64(2), 0))])
             .unwrap();
-        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(state.overlay_sizes_for_testing(), (0, 0, 0));
         assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
 
         // A later commit's row supersedes the flushed one through the overlay.
-        let v7 = live_row(Version::from_u64(7), 2);
+        let v7 = generate_live_entry(Version::from_u64(7), 2);
         epoch_store
             .record_commit_fully_executed(2, &[(id, v7)])
             .unwrap();
@@ -1951,7 +1951,7 @@ mod handler_object_state_storage {
         let epoch_store = authority.epoch_store_for_testing();
 
         let mutated = ObjectId::random();
-        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         let lamport = effects.lamport_version();
 
         // The digest is not in the round map: this execution is state sync
@@ -1962,7 +1962,7 @@ mod handler_object_state_storage {
 
         assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), None);
         assert_eq!(
-            epoch_store.sync_record(&mutated).unwrap(),
+            epoch_store.sync_ahead_record(&mutated).unwrap(),
             Some(SyncAheadRecord {
                 base_version: Some(Version::from_u64(5)),
                 latest_created: lamport,
@@ -1976,12 +1976,12 @@ mod handler_object_state_storage {
 
         // A second sync-executed transaction consuming the chain's output
         // extends the record without touching its previous version.
-        let (next_effects, next_inputs) = sync_executed_tx(mutated, lamport.as_u64(), 2);
+        let (next_effects, next_inputs) = executed_owned_tx_effects(mutated, lamport.as_u64(), 2);
         epoch_store
             .record_executed_transaction(&next_effects, &next_inputs)
             .unwrap();
         assert_eq!(
-            epoch_store.sync_record(&mutated).unwrap(),
+            epoch_store.sync_ahead_record(&mutated).unwrap(),
             Some(SyncAheadRecord {
                 base_version: Some(Version::from_u64(5)),
                 latest_created: next_effects.lamport_version(),
@@ -2006,7 +2006,7 @@ mod handler_object_state_storage {
             .unwrap();
         let created_version = create_effects.lamport_version();
         assert_eq!(
-            epoch_store.sync_record(&created).unwrap(),
+            epoch_store.sync_ahead_record(&created).unwrap(),
             Some(SyncAheadRecord {
                 base_version: None,
                 latest_created: created_version,
@@ -2017,12 +2017,12 @@ mod handler_object_state_storage {
         // `base_version: None`: the consumed version exists only on
         // validators that synced ahead, so no named version may answer keep.
         let (mutate_effects, mutate_inputs) =
-            sync_executed_tx(created, created_version.as_u64(), 2);
+            executed_owned_tx_effects(created, created_version.as_u64(), 2);
         epoch_store
             .record_executed_transaction(&mutate_effects, &mutate_inputs)
             .unwrap();
         assert_eq!(
-            epoch_store.sync_record(&created).unwrap(),
+            epoch_store.sync_ahead_record(&created).unwrap(),
             Some(SyncAheadRecord {
                 base_version: None,
                 latest_created: mutate_effects.lamport_version(),
@@ -2038,12 +2038,12 @@ mod handler_object_state_storage {
         // A sync-ahead chain runs and its record becomes durable (the
         // checkpoint executor's flush).
         let mutated = ObjectId::random();
-        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         epoch_store
             .record_executed_transaction(&effects, &loaded_inputs)
             .unwrap();
         let first_chain_head = effects.lamport_version();
-        let first_record = epoch_store.sync_record(&mutated).unwrap().unwrap();
+        let first_record = epoch_store.sync_ahead_record(&mutated).unwrap().unwrap();
         epoch_store
             .flush_sync_ahead_rows_for_testing(vec![(mutated, first_record)], vec![])
             .unwrap();
@@ -2052,17 +2052,18 @@ mod handler_object_state_storage {
         // (shadowed by the handler-latest row) until its queued deletion
         // drains.
         epoch_store
-            .record_commit_fully_executed(8, &[(mutated, live_row(first_chain_head, 8))])
+            .record_commit_fully_executed(8, &[(mutated, generate_live_entry(first_chain_head, 8))])
             .unwrap();
         assert_eq!(
-            epoch_store.sync_record(&mutated).unwrap(),
+            epoch_store.sync_ahead_record(&mutated).unwrap(),
             Some(first_record)
         );
 
         // A second chain starts before the deletion drains: it must get a
         // fresh base (the handler-written version it consumed), not extend
         // the dead record.
-        let (next_effects, next_inputs) = sync_executed_tx(mutated, first_chain_head.as_u64(), 2);
+        let (next_effects, next_inputs) =
+            executed_owned_tx_effects(mutated, first_chain_head.as_u64(), 2);
         epoch_store
             .record_executed_transaction(&next_effects, &next_inputs)
             .unwrap();
@@ -2070,7 +2071,10 @@ mod handler_object_state_storage {
             base_version: Some(first_chain_head),
             latest_created: next_effects.lamport_version(),
         };
-        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), Some(record));
+        assert_eq!(
+            epoch_store.sync_ahead_record(&mutated).unwrap(),
+            Some(record)
+        );
 
         // The stale queued deletion was canceled: draining (a commit flush)
         // after the new record becomes durable must not destroy it.
@@ -2078,7 +2082,10 @@ mod handler_object_state_storage {
             .flush_sync_ahead_rows_for_testing(vec![(mutated, record)], vec![])
             .unwrap();
         epoch_store.flush_commit_rows_for_testing(vec![]).unwrap();
-        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), Some(record));
+        assert_eq!(
+            epoch_store.sync_ahead_record(&mutated).unwrap(),
+            Some(record)
+        );
     }
 
     #[tokio::test]
@@ -2087,7 +2094,7 @@ mod handler_object_state_storage {
         let epoch_store = authority.epoch_store_for_testing();
 
         let mutated = ObjectId::random();
-        let (effects, _) = sync_executed_tx(mutated, 5, 1);
+        let (effects, _) = executed_owned_tx_effects(mutated, 5, 1);
 
         epoch_store.assign_commit_to_transactions(6, vec![*effects.transaction_digest()]);
         epoch_store
@@ -2100,7 +2107,7 @@ mod handler_object_state_storage {
             .expect("handler-latest row must exist for a handler-known commit");
         assert_eq!(row.produced_at, 6);
         assert_eq!(row.version, effects.lamport_version());
-        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), None);
+        assert_eq!(epoch_store.sync_ahead_record(&mutated).unwrap(), None);
         assert_eq!(
             epoch_store
                 .sheltered_object(&ObjectKey(mutated, Version::from_u64(5)))
@@ -2116,19 +2123,19 @@ mod handler_object_state_storage {
 
         // State sync executes a transaction ahead of the handler.
         let mutated = ObjectId::random();
-        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         epoch_store
             .record_executed_transaction(&effects, &loaded_inputs)
             .unwrap();
-        assert!(epoch_store.sync_record(&mutated).unwrap().is_some());
+        assert!(epoch_store.sync_ahead_record(&mutated).unwrap().is_some());
 
         // The handler catches up past the whole chain: the sync record goes,
         // the handler-latest row answers instead.
-        let row = live_row(effects.lamport_version(), 8);
+        let row = generate_live_entry(effects.lamport_version(), 8);
         epoch_store
             .record_commit_fully_executed(8, &[(mutated, row)])
             .unwrap();
-        assert_eq!(epoch_store.sync_record(&mutated).unwrap(), None);
+        assert_eq!(epoch_store.sync_ahead_record(&mutated).unwrap(), None);
         assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), Some(row));
     }
 
@@ -2139,7 +2146,7 @@ mod handler_object_state_storage {
         let state = epoch_store.handler_object_state_for_testing();
 
         let mutated = ObjectId::random();
-        let (effects, loaded_inputs) = sync_executed_tx(mutated, 5, 1);
+        let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         let gas = loaded_inputs[1].id();
         epoch_store
             .record_executed_transaction(&effects, &loaded_inputs)
@@ -2149,7 +2156,7 @@ mod handler_object_state_storage {
         // are served from the durable tables with empty overlays.
         let sync_rows: Vec<(ObjectId, SyncAheadRecord)> = [mutated, gas]
             .iter()
-            .map(|id| (*id, epoch_store.sync_record(id).unwrap().unwrap()))
+            .map(|id| (*id, epoch_store.sync_ahead_record(id).unwrap().unwrap()))
             .collect();
         let shelter_rows: Vec<(ObjectKey, Arc<Object>)> = [
             ObjectKey(mutated, Version::from_u64(5)),
@@ -2162,9 +2169,9 @@ mod handler_object_state_storage {
             .flush_sync_ahead_rows_for_testing(sync_rows.clone(), shelter_rows.clone())
             .unwrap();
 
-        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(state.overlay_sizes_for_testing(), (0, 0, 0));
         for (id, record) in &sync_rows {
-            assert_eq!(epoch_store.sync_record(id).unwrap(), Some(*record));
+            assert_eq!(epoch_store.sync_ahead_record(id).unwrap(), Some(*record));
         }
         for (key, object) in &shelter_rows {
             assert_eq!(

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -587,6 +587,11 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     pcool_skip_immutable_object_locks: bool,
 
+    // If true, P-COOL post-consensus validation reads object state as of the
+    // commit height being processed. Requires `enable_pcool_flow`.
+    #[serde(skip_serializing_if = "is_false")]
+    pcool_deterministic_validation: bool,
+
     // If true perform consistent verification of metadata
     #[serde(skip_serializing_if = "is_false")]
     validator_metadata_verify_v2: bool,
@@ -1949,6 +1954,15 @@ impl ProtocolConfig {
 
     pub fn pcool_skip_immutable_object_locks(&self) -> bool {
         self.feature_flags.pcool_skip_immutable_object_locks
+    }
+
+    pub fn pcool_deterministic_validation(&self) -> bool {
+        let res = self.feature_flags.pcool_deterministic_validation;
+        assert!(
+            !res || self.enable_pcool_flow(),
+            "pcool_deterministic_validation requires enable_pcool_flow to be enabled"
+        );
+        res
     }
 
     pub fn validator_metadata_verify_v2(&self) -> bool {
@@ -3616,6 +3630,10 @@ impl ProtocolConfig {
 
     pub fn set_pcool_skip_immutable_object_locks_for_testing(&mut self, val: bool) {
         self.feature_flags.pcool_skip_immutable_object_locks = val;
+    }
+
+    pub fn set_pcool_deterministic_validation_for_testing(&mut self, val: bool) {
+        self.feature_flags.pcool_deterministic_validation = val;
     }
 
     pub fn set_commits_per_schedule_for_testing(&mut self, val: u32) {


### PR DESCRIPTION
# Description of change

First increment of deterministic post-consensus validation for P-COOL: validation is meant to read object state as of the commit height the consensus handler is processing, independent of local execution and state-sync progress. This PR adds the state that view is built from; nothing reads it yet.

- Adds the `pcool_deterministic_validation` protocol feature flag. It is off on every chain and there is no protocol version bump; the getter requires `enable_pcool_flow`.
- Adds `handler_object_state`, a child module of the per-epoch store, with three per-epoch tables and their in-memory overlays: handler-latest rows (the latest state per object as of the handler frontier), sync-ahead records (per-object markers for state-sync-driven execution the handler has not reached yet), and sheltered consumed-input bytes (kept until the handler passes the consuming commit, so validation reads survive pruning).
- Adds the digest to commit-round map and the operations composing the overlays with the durable tables: version-monotone upserts, overlay-first reads with a read-through cache over the handler-latest table, and eviction only after the corresponding table row is durable.

No production caller is wired in this PR. The execution hook lands in #12846, which sits on top of this one in the stack; the consensus-handler commit-completion signal and the checkpoint-executor persistence follow in later increments. Visibility is temporarily `pub` so the module is not dead code under `-D warnings` until those consumers exist. Small cleanups of this module found in its review (cache-first durable read in the upsert path, collapsing a commit's rows to one per id before flush, returning `Object` instead of `Arc<Object>` from the shelter read) land in the follow-up PR together with the tests that exercise them.

## Links to any relevant issues

Related: iotaledger/iota-private#501

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes