### PR TITLE
feat(iota-core): record executed transactions in the P-COOL bookkeeping

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1833,6 +1833,20 @@ impl AuthorityState {
             epoch_store.insert_tx_key(key, *tx_digest)?;
         }
 
+        if epoch_store
+            .protocol_config()
+            .pcool_deterministic_validation()
+        {
+            // A consumed input version comes from the declared inputs; the
+            // store fallback covers the versions execution loaded at runtime
+            // (dynamic-field children and received objects).
+            let loaded_input_objects = ObjectStoreWithFallback {
+                primary: &inner_temporary_store.input_objects,
+                fallback: self.get_object_store().as_ref(),
+            };
+            epoch_store.record_executed_transaction(effects, &loaded_input_objects)?;
+        }
+
         // Allow testing what happens if we crash here.
         fail_point!("crash");
 
@@ -6202,6 +6216,37 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         Ok(self
             .get_transaction_cache_reader()
             .multi_get_events(digests))
+    }
+}
+
+/// An [`ObjectStore`] serving from `primary` first and `fallback` on a miss;
+/// the object-store sibling of
+/// [`PackageStoreWithFallback`](iota_types::inner_temporary_store::PackageStoreWithFallback).
+struct ObjectStoreWithFallback<P, F> {
+    primary: P,
+    fallback: F,
+}
+
+impl<P: ObjectStore, F: ObjectStore> ObjectStore for ObjectStoreWithFallback<P, F> {
+    fn try_get_object(
+        &self,
+        object_id: &ObjectId,
+    ) -> iota_types::storage::error::Result<Option<Object>> {
+        match self.primary.try_get_object(object_id)? {
+            Some(object) => Ok(Some(object)),
+            None => self.fallback.try_get_object(object_id),
+        }
+    }
+
+    fn try_get_object_by_key(
+        &self,
+        object_id: &ObjectId,
+        version: VersionNumber,
+    ) -> iota_types::storage::error::Result<Option<Object>> {
+        match self.primary.try_get_object_by_key(object_id, version)? {
+            Some(object) => Ok(Some(object)),
+            None => self.fallback.try_get_object_by_key(object_id, version),
+        }
     }
 }
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -60,7 +60,7 @@ use iota_types::{
         VerifiedAuthorityCapabilitiesV1, VersionedDkgConfirmation,
     },
     object::Object,
-    storage::{BackingPackageStore, InputKey, ObjectKey},
+    storage::{BackingPackageStore, InputKey, ObjectKey, ObjectStore},
     transaction::{
         CertifiedTransaction, InputObjectKind, SenderSignedTransactionAPI, TransactionAPI,
         TransactionEnvelope, TransactionKey, TxValidityCheckContext, VerifiedCertificate,
@@ -1777,7 +1777,7 @@ impl AuthorityPerEpochStore {
     pub fn record_executed_transaction(
         &self,
         effects: &TransactionEffects,
-        loaded_input_objects: &[Object],
+        loaded_input_objects: &dyn ObjectStore,
     ) -> IotaResult {
         let tables = self.tables()?;
         self.handler_object_state.record_executed_transaction(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1812,7 +1812,7 @@ impl AuthorityPerEpochStore {
     }
 
     /// The sheltered bytes of a consumed input version.
-    pub fn sheltered_object(&self, key: &ObjectKey) -> IotaResult<Option<Arc<Object>>> {
+    pub fn sheltered_object(&self, key: &ObjectKey) -> IotaResult<Option<Object>> {
         let tables = self.tables()?;
         self.handler_object_state.sheltered_object(&tables, key)
     }
@@ -1831,6 +1831,7 @@ impl AuthorityPerEpochStore {
         handler_rows: Vec<(ObjectId, HandlerLatestObject)>,
     ) -> IotaResult {
         let tables = self.tables()?;
+        let handler_rows = handler_object_state::highest_row_per_id(&handler_rows);
         let mut batch = tables.handler_latest_objects.batch();
         self.handler_object_state
             .write_commit_rows_to_batch(&tables, &mut batch, &handler_rows)?;
@@ -1847,7 +1848,7 @@ impl AuthorityPerEpochStore {
     pub fn flush_sync_ahead_rows_for_testing(
         &self,
         sync_rows: Vec<(ObjectId, SyncAheadRecord)>,
-        shelter_rows: Vec<(ObjectKey, Arc<Object>)>,
+        shelter_rows: Vec<(ObjectKey, Object)>,
     ) -> IotaResult {
         let tables = self.tables()?;
         let mut batch = tables.sync_ahead_records.batch();

--- a/crates/iota-core/src/authority/handler_object_state.rs
+++ b/crates/iota-core/src/authority/handler_object_state.rs
@@ -47,10 +47,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use dashmap::DashMap;
@@ -247,6 +244,24 @@ pub fn sync_ahead_writes(
     writes
 }
 
+/// Collapses a commit's per-transaction rows to one row per id, the highest
+/// version winning. The per-transaction upserts carry one entry per write, so
+/// an id written by several of the commit's transactions (a sender's gas coin,
+/// an object mutated twice) appears more than once, in no particular order;
+/// the flush takes the collapsed form.
+pub fn highest_row_per_id(
+    rows: &[(ObjectId, HandlerLatestObject)],
+) -> BTreeMap<ObjectId, HandlerLatestObject> {
+    let mut highest = BTreeMap::new();
+    for (id, row) in rows {
+        let current = highest.entry(*id).or_insert(*row);
+        if row.is_newer_than(current) {
+            *current = *row;
+        }
+    }
+    highest
+}
+
 /// The input versions a transaction consumed that shelter rows must cover:
 /// address-owned versions, plus object-owned children conservatively (pending
 /// the deferred receiving-objects design). Shared inputs are existence-only
@@ -278,7 +293,7 @@ pub struct HandlerObjectState {
 
     handler_latest_overlay: RwLock<BTreeMap<ObjectId, HandlerLatestObject>>,
     sync_ahead_overlay: RwLock<BTreeMap<ObjectId, SyncAheadRecord>>,
-    sheltered_overlay: RwLock<BTreeMap<ObjectKey, Arc<Object>>>,
+    sheltered_overlay: RwLock<BTreeMap<ObjectKey, Object>>,
 
     /// Sync-ahead records the handler has caught up past, pending deletion
     /// from the durable table; drained into the next flush batch.
@@ -417,15 +432,28 @@ impl HandlerObjectState {
         id: &ObjectId,
     ) -> IotaResult<Option<HandlerLatestObject>> {
         // The ticket snapshots this object's cache generation before any
-        // read. The cache fill below succeeds only if the generation is
-        // still the same; a flush that caches a newer row in the meantime
-        // (`Ticket::Write` in `evict_flushed_commit_rows`) bumps it, and the
-        // fill is discarded - the row read from the table here would be
-        // older than what the flush cached, and must not replace it.
+        // read, so a flush landing between the overlay check and the cache
+        // fill cannot be shadowed by the table row read here.
         let ticket = self.handler_latest_cache.get_ticket_for_read(id);
         if let Some(row) = self.handler_latest_overlay.read().get(id) {
             return Ok(Some(*row));
         }
+        self.durable_handler_latest(tables, id, ticket)
+    }
+
+    /// The durable handler-latest row of `id`, through the read-through
+    /// cache. `ticket` must have been taken before any read for this call: the
+    /// cache fill below succeeds only if the object's cache generation is
+    /// still the one the ticket saw; a flush that caches a newer row in the
+    /// meantime (`Ticket::Write` in `evict_flushed_commit_rows`) bumps it, and
+    /// the fill is discarded - the row read from the table here would be
+    /// older than what the flush cached, and must not replace it.
+    fn durable_handler_latest(
+        &self,
+        tables: &AuthorityEpochTables,
+        id: &ObjectId,
+        ticket: Ticket,
+    ) -> IotaResult<Option<HandlerLatestObject>> {
         if let Some(entry) = self.handler_latest_cache.get(id) {
             return Ok(Some(*entry.lock()));
         }
@@ -454,11 +482,11 @@ impl HandlerObjectState {
         &self,
         tables: &AuthorityEpochTables,
         key: &ObjectKey,
-    ) -> IotaResult<Option<Arc<Object>>> {
+    ) -> IotaResult<Option<Object>> {
         if let Some(object) = self.sheltered_overlay.read().get(key) {
             return Ok(Some(object.clone()));
         }
-        Ok(tables.sheltered_objects.get(key)?.map(Arc::new))
+        Ok(tables.sheltered_objects.get(key)?)
     }
 
     /// Stages a commit's handler-latest rows into `batch` - the quarantine
@@ -471,19 +499,17 @@ impl HandlerObjectState {
     /// store state. After the batch is durably written - never before - pass
     /// the same rows to [`Self::evict_flushed_commit_rows`].
     ///
-    /// These writes carry no version guard: the caller must flush commits in
-    /// commit order, one flush at a time (the quarantine flush does), or an
-    /// older row could overwrite a newer durable one.
+    /// `handler_rows` is the commit's collapsed row set
+    /// ([`highest_row_per_id`]). The writes carry no version guard: the caller
+    /// must flush commits in commit order, one flush at a time (the quarantine
+    /// flush does), or an older row could overwrite a newer durable one.
     pub fn write_commit_rows_to_batch(
         &self,
         tables: &AuthorityEpochTables,
         batch: &mut DBBatch,
-        handler_rows: &[(ObjectId, HandlerLatestObject)],
+        handler_rows: &BTreeMap<ObjectId, HandlerLatestObject>,
     ) -> IotaResult {
-        batch.insert_batch(
-            &tables.handler_latest_objects,
-            handler_rows.iter().map(|(id, row)| (id, row)),
-        )?;
+        batch.insert_batch(&tables.handler_latest_objects, handler_rows.iter())?;
         // A deletion lost to a batch that never commits is re-queued when the
         // commit replays.
         let deletions = std::mem::take(&mut *self.sync_ahead_record_deletions.lock());
@@ -492,11 +518,17 @@ impl HandlerObjectState {
     }
 
     /// Evicts a commit's handler-latest overlay entries once their rows are
-    /// durable. The cache is refreshed write-through before each entry is
-    /// removed, so a concurrent reader never observes a row absent from both;
-    /// an entry upserted again since the flush (a newer, still-unflushed row)
-    /// is kept.
-    pub fn evict_flushed_commit_rows(&self, handler_rows: &[(ObjectId, HandlerLatestObject)]) {
+    /// durable; the caller's write-then-evict order is what keeps a concurrent
+    /// reader from finding a row in neither the overlay nor the table. The
+    /// rows are cached on the way out with a write ticket, which expires the
+    /// read tickets of readers still holding the pre-flush table row (see
+    /// [`Self::durable_handler_latest`]); the cached value itself is
+    /// best-effort. An entry upserted again since the flush (a newer,
+    /// still-unflushed row) is kept.
+    pub fn evict_flushed_commit_rows(
+        &self,
+        handler_rows: &BTreeMap<ObjectId, HandlerLatestObject>,
+    ) {
         let mut overlay = self.handler_latest_overlay.write();
         for (id, row) in handler_rows {
             self.handler_latest_cache
@@ -523,7 +555,7 @@ impl HandlerObjectState {
         tables: &AuthorityEpochTables,
         batch: &mut DBBatch,
         sync_rows: &[(ObjectId, SyncAheadRecord)],
-        shelter_rows: &[(ObjectKey, Arc<Object>)],
+        shelter_rows: &[(ObjectKey, Object)],
     ) -> IotaResult {
         batch.insert_batch(
             &tables.sync_ahead_records,
@@ -531,9 +563,7 @@ impl HandlerObjectState {
         )?;
         batch.insert_batch(
             &tables.sheltered_objects,
-            shelter_rows
-                .iter()
-                .map(|(key, object)| (key, object.as_ref())),
+            shelter_rows.iter().map(|(key, object)| (key, object)),
         )?;
         Ok(())
     }
@@ -548,7 +578,7 @@ impl HandlerObjectState {
     pub fn evict_flushed_sync_ahead_rows(
         &self,
         sync_rows: &[(ObjectId, SyncAheadRecord)],
-        shelter_rows: &[(ObjectKey, Arc<Object>)],
+        shelter_rows: &[(ObjectKey, Object)],
     ) {
         {
             let mut overlay = self.sync_ahead_overlay.write();
@@ -586,9 +616,10 @@ impl HandlerObjectState {
         let mut overlay = self.handler_latest_overlay.write();
         for (id, row) in rows {
             match overlay.get(id) {
-                // The writers racing on one id within a commit all write the
-                // same value; across commits a later commit's row always has
-                // a higher version, so the guard makes the row a monotone
+                // Within a commit an id may carry several versions (written
+                // by several of its transactions) and the highest wins;
+                // across commits a later commit's row always has a higher
+                // version. Either way the guard makes the row a monotone
                 // function of handler progress.
                 Some(current) => {
                     if row.version >= current.version {
@@ -602,8 +633,12 @@ impl HandlerObjectState {
                     // shadowing the newer durable one through the
                     // overlay-first read; strict `>` also keeps a watcher
                     // firing after its commit flushed from re-adding a row
-                    // nothing would ever evict.
-                    let durable = tables.handler_latest_objects.get(id)?;
+                    // nothing would ever evict. Read through the cache: a
+                    // flush cannot land while the overlay lock is held, so
+                    // cache and table agree; a cache miss still costs a table
+                    // read under the lock.
+                    let ticket = self.handler_latest_cache.get_ticket_for_read(id);
+                    let durable = self.durable_handler_latest(tables, id, ticket)?;
                     if durable.is_none_or(|durable| row.version > durable.version) {
                         overlay.insert(*id, *row);
                     }
@@ -688,7 +723,7 @@ impl HandlerObjectState {
             .zip(loaded_input_objects.try_multi_get_objects_by_key(&keys)?)
         {
             match object {
-                Some(object) => rows.push((*key, Arc::new(object))),
+                Some(object) => rows.push((*key, object)),
                 None => debug_fatal!(
                     "input {key:?} consumed by sync-executed transaction {tx_digest} missing from \
                  the loaded inputs; its bytes cannot be sheltered against pruning"

--- a/crates/iota-core/src/authority/handler_object_state.rs
+++ b/crates/iota-core/src/authority/handler_object_state.rs
@@ -64,7 +64,7 @@ use iota_types::{
     effects::{TransactionEffectsAPI, TransactionEffectsExt},
     error::IotaResult,
     object::Object,
-    storage::ObjectKey,
+    storage::{ObjectKey, ObjectStore},
 };
 use itertools::chain;
 use parking_lot::{Mutex, RwLock};
@@ -356,16 +356,16 @@ impl HandlerObjectState {
     /// it wrote and shelters the bytes of the owned input versions it
     /// consumed.
     ///
-    /// `loaded_input_objects` must contain every consumed owned input at its
+    /// `loaded_input_objects` must serve every consumed owned input at its
     /// consumed version - including dynamic-field children and received
-    /// objects, which are not part of the declared input objects; a missing
-    /// one cannot be sheltered against pruning and is reported through
-    /// `debug_fatal`.
+    /// objects, which are not part of the transaction's declared input objects;
+    /// a missing one cannot be sheltered against pruning and is reported
+    /// through `debug_fatal`.
     pub fn record_executed_transaction(
         &self,
         tables: &AuthorityEpochTables,
         effects: &TransactionEffects,
-        loaded_input_objects: &[Object],
+        loaded_input_objects: &dyn ObjectStore,
     ) -> IotaResult {
         if let Some(round) = self.commit_round_of(effects.transaction_digest()) {
             self.upsert_handler_latest_rows(tables, &handler_latest_upserts(effects, round))
@@ -376,8 +376,7 @@ impl HandlerObjectState {
                 consumed_input_keys_to_shelter(&old_metadata),
                 loaded_input_objects,
                 effects.transaction_digest(),
-            );
-            Ok(())
+            )
         }
     }
 
@@ -676,30 +675,32 @@ impl HandlerObjectState {
     fn shelter_consumed_inputs(
         &self,
         keys: Vec<ObjectKey>,
-        loaded_input_objects: &[Object],
+        loaded_input_objects: &dyn ObjectStore,
         tx_digest: &TransactionDigest,
-    ) {
+    ) -> IotaResult {
         if keys.is_empty() {
-            return;
+            return Ok(());
         }
-        let mut needed: BTreeSet<ObjectKey> = keys.into_iter().collect();
-        let mut overlay = self.sheltered_overlay.write();
-        for object in loaded_input_objects {
-            let key = ObjectKey(object.id(), object.version());
-            // A replay after a crash may re-insert rows that are already
-            // durable; that is fine - the checkpoint executor's persist step
-            // re-runs on the same replay and evicts them again, and the
-            // bytes are identical either way.
-            if needed.remove(&key) {
-                overlay.insert(key, Arc::new(object.clone()));
+        // Resolve outside the overlay lock: the store reads can reach the DB.
+        let mut rows = Vec::with_capacity(keys.len());
+        for (key, object) in keys
+            .iter()
+            .zip(loaded_input_objects.try_multi_get_objects_by_key(&keys)?)
+        {
+            match object {
+                Some(object) => rows.push((*key, Arc::new(object))),
+                None => debug_fatal!(
+                    "input {key:?} consumed by sync-executed transaction {tx_digest} missing from \
+                 the loaded inputs; its bytes cannot be sheltered against pruning"
+                ),
             }
         }
-        for key in needed {
-            debug_fatal!(
-                "input {key:?} consumed by sync-executed transaction {tx_digest} missing from \
-                 the loaded inputs; its bytes cannot be sheltered against pruning"
-            );
-        }
+        // A replay after a crash may re-insert rows that are already durable;
+        // that is fine - the checkpoint executor's persist step re-runs on the
+        // same replay and evicts them again, and the bytes are identical
+        // either way.
+        self.sheltered_overlay.write().extend(rows);
+        Ok(())
     }
 
     fn remove_handled_sync_ahead_records(

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1974,8 +1974,8 @@ mod handler_object_state_storage {
         // Two transactions of one commit write the same id (a sender's gas
         // coin), so the commit's rows carry both versions, here out of
         // version order.
-        let v3 = live_row(Version::from_u64(3), 1);
-        let v5 = live_row(Version::from_u64(5), 1);
+        let v3 = generate_live_entry(Version::from_u64(3), 1);
+        let v5 = generate_live_entry(Version::from_u64(5), 1);
         let commit_rows = vec![(id, v5), (id, v3)];
         epoch_store
             .record_commit_fully_executed(1, &commit_rows)
@@ -1988,7 +1988,7 @@ mod handler_object_state_storage {
         epoch_store
             .flush_commit_rows_for_testing(commit_rows)
             .unwrap();
-        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(state.overlay_sizes_for_testing(), (0, 0, 0));
         assert_eq!(
             epoch_store
                 .tables()

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1830,7 +1830,7 @@ mod handler_object_state_storage {
         base_types::CommitRound,
         effects::{TestEffectsBuilder, TransactionEffectsAPI},
         object::Object,
-        storage::ObjectKey,
+        storage::{ObjectKey, ObjectStore},
         transaction::TransactionAPI,
     };
 
@@ -1838,6 +1838,27 @@ mod handler_object_state_storage {
     use crate::authority::authority_per_epoch_store::handler_object_state::{
         HandlerLatestObject, HandlerLatestObjectKind, SyncAheadRecord,
     };
+
+    /// An [`ObjectStore`] for the map-hit arm: a handler-known transaction
+    /// must never fetch shelter bytes.
+    struct NoShelterFetch;
+
+    impl ObjectStore for NoShelterFetch {
+        fn try_get_object(
+            &self,
+            _: &ObjectId,
+        ) -> iota_types::storage::error::Result<Option<Object>> {
+            unreachable!("a handler-known transaction must not fetch shelter bytes")
+        }
+
+        fn try_get_object_by_key(
+            &self,
+            _: &ObjectId,
+            _: Version,
+        ) -> iota_types::storage::error::Result<Option<Object>> {
+            unreachable!("a handler-known transaction must not fetch shelter bytes")
+        }
+    }
 
     fn owned_object(id: ObjectId, version: u64) -> Object {
         Object::with_id_owner_version_for_testing(
@@ -1957,7 +1978,7 @@ mod handler_object_state_storage {
         // The digest is not in the round map: this execution is state sync
         // running ahead of the handler.
         epoch_store
-            .record_executed_transaction(&effects, &loaded_inputs)
+            .record_executed_transaction(&effects, &loaded_inputs.as_slice())
             .unwrap();
 
         assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), None);
@@ -1978,7 +1999,7 @@ mod handler_object_state_storage {
         // extends the record without touching its previous version.
         let (next_effects, next_inputs) = executed_owned_tx_effects(mutated, lamport.as_u64(), 2);
         epoch_store
-            .record_executed_transaction(&next_effects, &next_inputs)
+            .record_executed_transaction(&next_effects, &next_inputs.as_slice())
             .unwrap();
         assert_eq!(
             epoch_store.sync_ahead_record(&mutated).unwrap(),
@@ -2001,8 +2022,9 @@ mod handler_object_state_storage {
             .with_created_objects([(created, Owner::Address(Address::ZERO))])
             .build();
         let gas = create_tx.transaction().gas()[0].object_id;
+        let create_inputs = [owned_object(gas, 1)];
         epoch_store
-            .record_executed_transaction(&create_effects, &[owned_object(gas, 1)])
+            .record_executed_transaction(&create_effects, &create_inputs.as_slice())
             .unwrap();
         let created_version = create_effects.lamport_version();
         assert_eq!(
@@ -2019,7 +2041,7 @@ mod handler_object_state_storage {
         let (mutate_effects, mutate_inputs) =
             executed_owned_tx_effects(created, created_version.as_u64(), 2);
         epoch_store
-            .record_executed_transaction(&mutate_effects, &mutate_inputs)
+            .record_executed_transaction(&mutate_effects, &mutate_inputs.as_slice())
             .unwrap();
         assert_eq!(
             epoch_store.sync_ahead_record(&created).unwrap(),
@@ -2040,7 +2062,7 @@ mod handler_object_state_storage {
         let mutated = ObjectId::random();
         let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         epoch_store
-            .record_executed_transaction(&effects, &loaded_inputs)
+            .record_executed_transaction(&effects, &loaded_inputs.as_slice())
             .unwrap();
         let first_chain_head = effects.lamport_version();
         let first_record = epoch_store.sync_ahead_record(&mutated).unwrap().unwrap();
@@ -2065,7 +2087,7 @@ mod handler_object_state_storage {
         let (next_effects, next_inputs) =
             executed_owned_tx_effects(mutated, first_chain_head.as_u64(), 2);
         epoch_store
-            .record_executed_transaction(&next_effects, &next_inputs)
+            .record_executed_transaction(&next_effects, &next_inputs.as_slice())
             .unwrap();
         let record = SyncAheadRecord {
             base_version: Some(first_chain_head),
@@ -2098,7 +2120,7 @@ mod handler_object_state_storage {
 
         epoch_store.assign_commit_to_transactions(6, vec![*effects.transaction_digest()]);
         epoch_store
-            .record_executed_transaction(&effects, &[])
+            .record_executed_transaction(&effects, &NoShelterFetch)
             .unwrap();
 
         let row = epoch_store
@@ -2125,7 +2147,7 @@ mod handler_object_state_storage {
         let mutated = ObjectId::random();
         let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         epoch_store
-            .record_executed_transaction(&effects, &loaded_inputs)
+            .record_executed_transaction(&effects, &loaded_inputs.as_slice())
             .unwrap();
         assert!(epoch_store.sync_ahead_record(&mutated).unwrap().is_some());
 
@@ -2149,7 +2171,7 @@ mod handler_object_state_storage {
         let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
         let gas = loaded_inputs[1].id();
         epoch_store
-            .record_executed_transaction(&effects, &loaded_inputs)
+            .record_executed_transaction(&effects, &loaded_inputs.as_slice())
             .unwrap();
 
         // Flush everything the sync execution wrote, then verify the reads

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -1820,8 +1820,6 @@ async fn failed_deny_rule_update_execution_asserts_on_derived_effects() {
 // === P-COOL deterministic-validation bookkeeping (handler_object_state) ===
 
 mod handler_object_state_storage {
-    use std::sync::Arc;
-
     use iota_sdk_types::{
         Address, ObjectDigest, ObjectReference, Owner, SenderSignedTransaction, TransactionEffects,
     };
@@ -1964,6 +1962,43 @@ mod handler_object_state_storage {
             .record_commit_fully_executed(2, &[(id, v7)])
             .unwrap();
         assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v7));
+    }
+
+    #[tokio::test]
+    async fn flushed_rows_for_one_id_collapse_to_the_highest_version() {
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+        let state = epoch_store.handler_object_state_for_testing();
+        let id = ObjectId::random();
+
+        // Two transactions of one commit write the same id (a sender's gas
+        // coin), so the commit's rows carry both versions, here out of
+        // version order.
+        let v3 = live_row(Version::from_u64(3), 1);
+        let v5 = live_row(Version::from_u64(5), 1);
+        let commit_rows = vec![(id, v5), (id, v3)];
+        epoch_store
+            .record_commit_fully_executed(1, &commit_rows)
+            .unwrap();
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
+
+        // The flush leaves the highest version durable - not the last one
+        // iterated - and evicts the overlay entry without the write-through
+        // cache insert of an older row tripping the monotonicity check.
+        epoch_store
+            .flush_commit_rows_for_testing(commit_rows)
+            .unwrap();
+        assert_eq!(state.overlay_lens_for_testing(), (0, 0, 0));
+        assert_eq!(
+            epoch_store
+                .tables()
+                .unwrap()
+                .handler_latest_objects
+                .get(&id)
+                .unwrap(),
+            Some(v5)
+        );
+        assert_eq!(epoch_store.handler_latest(&id).unwrap(), Some(v5));
     }
 
     #[tokio::test]
@@ -2180,7 +2215,7 @@ mod handler_object_state_storage {
             .iter()
             .map(|id| (*id, epoch_store.sync_ahead_record(id).unwrap().unwrap()))
             .collect();
-        let shelter_rows: Vec<(ObjectKey, Arc<Object>)> = [
+        let shelter_rows: Vec<(ObjectKey, Object)> = [
             ObjectKey(mutated, Version::from_u64(5)),
             ObjectKey(gas, Version::from_u64(1)),
         ]
@@ -2197,8 +2232,8 @@ mod handler_object_state_storage {
         }
         for (key, object) in &shelter_rows {
             assert_eq!(
-                epoch_store.sheltered_object(key).unwrap().as_deref(),
-                Some(object.as_ref())
+                epoch_store.sheltered_object(key).unwrap().as_ref(),
+                Some(object)
             );
         }
     }

--- a/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_per_epoch_store_tests.rs
@@ -2002,92 +2002,6 @@ mod handler_object_state_storage {
     }
 
     #[tokio::test]
-    async fn map_miss_writes_sync_records_and_shelter_but_never_handler_latest() {
-        let authority = TestAuthorityBuilder::new().build().await;
-        let epoch_store = authority.epoch_store_for_testing();
-
-        let mutated = ObjectId::random();
-        let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
-        let lamport = effects.lamport_version();
-
-        // The digest is not in the round map: this execution is state sync
-        // running ahead of the handler.
-        epoch_store
-            .record_executed_transaction(&effects, &loaded_inputs.as_slice())
-            .unwrap();
-
-        assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), None);
-        assert_eq!(
-            epoch_store.sync_ahead_record(&mutated).unwrap(),
-            Some(SyncAheadRecord {
-                base_version: Some(Version::from_u64(5)),
-                latest_created: lamport,
-            })
-        );
-        let sheltered = epoch_store
-            .sheltered_object(&ObjectKey(mutated, Version::from_u64(5)))
-            .unwrap()
-            .expect("consumed input must be sheltered");
-        assert_eq!(sheltered.version(), Version::from_u64(5));
-
-        // A second sync-executed transaction consuming the chain's output
-        // extends the record without touching its previous version.
-        let (next_effects, next_inputs) = executed_owned_tx_effects(mutated, lamport.as_u64(), 2);
-        epoch_store
-            .record_executed_transaction(&next_effects, &next_inputs.as_slice())
-            .unwrap();
-        assert_eq!(
-            epoch_store.sync_ahead_record(&mutated).unwrap(),
-            Some(SyncAheadRecord {
-                base_version: Some(Version::from_u64(5)),
-                latest_created: next_effects.lamport_version(),
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn sync_created_object_keeps_base_version_none_when_chain_extends() {
-        let authority = TestAuthorityBuilder::new().build().await;
-        let epoch_store = authority.epoch_store_for_testing();
-
-        // State sync creates the object ahead of the handler...
-        let created = ObjectId::random();
-        let create_tx = owned_inputs_tx(1);
-        let create_effects = TestEffectsBuilder::new(&create_tx)
-            .with_created_objects([(created, Owner::Address(Address::ZERO))])
-            .build();
-        let gas = create_tx.transaction().gas()[0].object_id;
-        let create_inputs = [owned_object(gas, 1)];
-        epoch_store
-            .record_executed_transaction(&create_effects, &create_inputs.as_slice())
-            .unwrap();
-        let created_version = create_effects.lamport_version();
-        assert_eq!(
-            epoch_store.sync_ahead_record(&created).unwrap(),
-            Some(SyncAheadRecord {
-                base_version: None,
-                latest_created: created_version,
-            })
-        );
-
-        // ...then consumes its own creation. The record must keep
-        // `base_version: None`: the consumed version exists only on
-        // validators that synced ahead, so no named version may answer keep.
-        let (mutate_effects, mutate_inputs) =
-            executed_owned_tx_effects(created, created_version.as_u64(), 2);
-        epoch_store
-            .record_executed_transaction(&mutate_effects, &mutate_inputs.as_slice())
-            .unwrap();
-        assert_eq!(
-            epoch_store.sync_ahead_record(&created).unwrap(),
-            Some(SyncAheadRecord {
-                base_version: None,
-                latest_created: mutate_effects.lamport_version(),
-            })
-        );
-    }
-
-    #[tokio::test]
     async fn recreated_sync_record_starts_fresh_and_survives_deletion_drain() {
         let authority = TestAuthorityBuilder::new().build().await;
         let epoch_store = authority.epoch_store_for_testing();
@@ -2145,8 +2059,11 @@ mod handler_object_state_storage {
         );
     }
 
+    /// The execution-hook tests cover the rows a handler-known execution
+    /// writes through real execution; this pins what real execution cannot:
+    /// a map hit does no shelter fetch at all.
     #[tokio::test]
-    async fn map_hit_writes_handler_latest_only() {
+    async fn map_hit_fetches_no_shelter_bytes() {
         let authority = TestAuthorityBuilder::new().build().await;
         let epoch_store = authority.epoch_store_for_testing();
 
@@ -2171,29 +2088,6 @@ mod handler_object_state_storage {
                 .unwrap(),
             None
         );
-    }
-
-    #[tokio::test]
-    async fn fully_executed_commit_cleans_sync_records_and_round_map() {
-        let authority = TestAuthorityBuilder::new().build().await;
-        let epoch_store = authority.epoch_store_for_testing();
-
-        // State sync executes a transaction ahead of the handler.
-        let mutated = ObjectId::random();
-        let (effects, loaded_inputs) = executed_owned_tx_effects(mutated, 5, 1);
-        epoch_store
-            .record_executed_transaction(&effects, &loaded_inputs.as_slice())
-            .unwrap();
-        assert!(epoch_store.sync_ahead_record(&mutated).unwrap().is_some());
-
-        // The handler catches up past the whole chain: the sync record goes,
-        // the handler-latest row answers instead.
-        let row = generate_live_entry(effects.lamport_version(), 8);
-        epoch_store
-            .record_commit_fully_executed(8, &[(mutated, row)])
-            .unwrap();
-        assert_eq!(epoch_store.sync_ahead_record(&mutated).unwrap(), None);
-        assert_eq!(epoch_store.handler_latest(&mutated).unwrap(), Some(row));
     }
 
     #[tokio::test]

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -9,16 +9,18 @@ use std::sync::Arc;
 use iota_macros::sim_test;
 use iota_protocol_config::{OverrideGuard, ProtocolConfig};
 use iota_sdk_types::{
-    Address, Command, Identifier, ObjectId, ObjectReference, Owner, Transaction, TransactionDigest,
-    Version,
+    Address, Command, Identifier, ObjectId, ObjectReference, OwnedObjectReference, Owner,
+    Transaction, TransactionDigest, TransactionEffects, Version,
 };
 use iota_types::{
     crypto::{AccountPrivateKey, get_key_pair},
+    effects::TransactionEffectsAPI,
     error::{IotaError, UserInputError},
     executable_transaction::VerifiedExecutableTransaction,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
+    storage::ObjectKey,
     transaction::{
         CallArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS, TransactionAPI, TransactionKey,
         VerifiedTransaction,
@@ -29,8 +31,13 @@ use iota_types::{
 use crate::{
     authority::{
         ExecutionEnv,
-        authority_per_epoch_store::{LockDetails, consensus_quarantine::ConsensusCommitOutput},
+        authority_per_epoch_store::{
+            LockDetails, consensus_quarantine::ConsensusCommitOutput,
+            handler_object_state::HandlerLatestObjectKind,
+        },
         authority_tests::init_state_with_objects_and_object_basics,
+        move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
+        test_authority_builder::TestAuthorityBuilder,
     },
     checkpoints::CheckpointServiceNoop,
     consensus_handler::{SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction},
@@ -2003,6 +2010,887 @@ async fn post_consensus_validation_applies_relaxed_rules() {
         "previously denied sender must be kept after withdrawal"
     );
     assert_eq!(locks.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// P-COOL deterministic-validation bookkeeping (execution hook)
+// ---------------------------------------------------------------------------
+
+/// Shared setup for the execution-hook bookkeeping tests: the P-COOL flags
+/// (held by `_config_guard` for the test's duration when enabled), plus
+/// helpers to execute transactions and assert the bookkeeping rows they
+/// leave. Execution provenance never matters to the hook - only whether the
+/// digest is registered in the digest -> commit-round map (handler-known)
+/// or not (sync-ahead).
+struct BookkeepingSetup {
+    authority: Arc<crate::authority::AuthorityState>,
+    epoch_store: Arc<crate::authority::authority_per_epoch_store::AuthorityPerEpochStore>,
+    package_id: ObjectId,
+    rgp: u64,
+    _config_guard: Option<OverrideGuard>,
+}
+
+async fn setup_bookkeeping(
+    genesis_objects: Vec<Object>,
+    validation_enabled: bool,
+) -> BookkeepingSetup {
+    let _config_guard = validation_enabled.then(|| {
+        ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_enable_pcool_flow_for_testing(true);
+            config.set_pcool_deterministic_validation_for_testing(true);
+            config
+        })
+    });
+
+    let (authority, package) = init_state_with_objects_and_object_basics(genesis_objects).await;
+    let epoch_store = (*authority.epoch_store_for_testing()).clone();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    BookkeepingSetup {
+        authority,
+        epoch_store,
+        package_id: package.object_id,
+        rgp,
+        _config_guard,
+    }
+}
+
+/// Like [`setup_bookkeeping`] with the flags on, but publishing the given
+/// test package instead of `object_basics`; `gas_id` is created at genesis
+/// for `sender` and funds the publish and the test's transactions.
+async fn setup_bookkeeping_with_package(
+    package_name: &str,
+    sender: Address,
+    sender_key: &AccountPrivateKey,
+    gas_id: ObjectId,
+) -> BookkeepingSetup {
+    let _config_guard = Some(ProtocolConfig::apply_overrides_for_testing(
+        |_, mut config| {
+            config.set_enable_pcool_flow_for_testing(true);
+            config.set_pcool_deterministic_validation_for_testing(true);
+            config
+        },
+    ));
+
+    let authority = TestAuthorityBuilder::new().build().await;
+    authority.insert_genesis_object(Object::with_id_owner_for_testing(gas_id, sender));
+    let (package, _) = build_and_publish_test_package_with_upgrade_cap(
+        &authority,
+        &sender,
+        sender_key,
+        &gas_id,
+        package_name,
+        false,
+    )
+    .await;
+    let epoch_store = (*authority.epoch_store_for_testing()).clone();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    BookkeepingSetup {
+        authority,
+        epoch_store,
+        package_id: package.object_id,
+        rgp,
+        _config_guard,
+    }
+}
+
+/// From the `tto::M1::start` effects, the `(parent, child)` pair where the
+/// child is address-owned by the parent object's id - the receivable shape.
+fn parent_and_child(
+    created: Vec<OwnedObjectReference>,
+) -> (OwnedObjectReference, OwnedObjectReference) {
+    created
+        .iter()
+        .find_map(|child| match child.owner {
+            Owner::Address(addr) => created
+                .iter()
+                .find(|parent| parent.reference.object_id == ObjectId::from(addr))
+                .map(|parent| (*parent, *child)),
+            _ => None,
+        })
+        .expect("start() creates a child owned by another created object's id")
+}
+
+impl BookkeepingSetup {
+    /// The latest reference of `id` in the authority's view.
+    fn latest_ref(&self, id: &ObjectId) -> ObjectReference {
+        self.authority.get_object(id).unwrap().object_ref()
+    }
+
+    /// A keyed read of `(id, version)` from the object store, the way
+    /// validation's content read would issue it; `None` for tombstones.
+    fn store_object(&self, id: &ObjectId, version: Version) -> Option<Object> {
+        self.authority
+            .get_object_cache_reader()
+            .get_object_by_key(id, version)
+    }
+
+    /// Executes `tx` directly (`new_from_checkpoint` merely avoids needing a
+    /// certificate). Unless the digest was registered in the digest ->
+    /// commit-round map beforehand, the hook classifies it sync-ahead.
+    fn execute(&self, tx: VerifiedTransaction) -> TransactionEffects {
+        let executable =
+            VerifiedExecutableTransaction::new_from_checkpoint(tx, self.epoch_store.epoch(), 1);
+        let (effects, _) = self
+            .authority
+            .try_execute_immediately(&executable, ExecutionEnv::new(), &self.epoch_store)
+            .unwrap();
+        assert!(effects.status().is_success(), "{:?}", effects.status());
+        effects
+    }
+
+    /// Builds a call into `module::function` of the published test package at
+    /// the gas coin's latest version and executes it through the state-sync
+    /// arm.
+    fn move_call(
+        &self,
+        module: &'static str,
+        function: &'static str,
+        args: Vec<CallArg>,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+    ) -> TransactionEffects {
+        let tx = Transaction::new_move_call(
+            sender,
+            self.package_id,
+            Identifier::from_static(module),
+            Identifier::from_static(function),
+            vec![],
+            self.latest_ref(gas_id),
+            args,
+            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * self.rgp,
+            self.rgp,
+        )
+        .unwrap();
+        let tx = to_sender_signed_transaction(tx, sender_key);
+        self.execute(self.epoch_store.verify_transaction(tx).unwrap())
+    }
+
+    /// [`Self::move_call`] into the `object_basics` module.
+    fn object_basics_call(
+        &self,
+        function: &'static str,
+        args: Vec<CallArg>,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+    ) -> TransactionEffects {
+        self.move_call("object_basics", function, args, gas_id, sender, sender_key)
+    }
+
+    /// Creates a fresh `object_basics::Object` owned by `sender`;
+    /// returns the created reference and the effects.
+    fn create_object(
+        &self,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+    ) -> (ObjectReference, TransactionEffects) {
+        let effects = self.object_basics_call(
+            "create",
+            vec![
+                CallArg::Pure(bcs::to_bytes(&16u64).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+            ],
+            gas_id,
+            sender,
+            sender_key,
+        );
+        (effects.created()[0].reference, effects)
+    }
+
+    /// Builds a transfer of `object_id` to `recipient` at the objects' latest
+    /// versions, paid by `gas_id`, and executes it.
+    fn transfer(
+        &self,
+        object_id: &ObjectId,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+        recipient: Address,
+    ) {
+        let tx = make_transfer_object_transaction(
+            self.latest_ref(object_id),
+            self.latest_ref(gas_id),
+            sender,
+            sender_key,
+            recipient,
+            self.rgp,
+        );
+        self.execute(self.epoch_store.verify_transaction(tx).unwrap());
+    }
+
+    /// Asserts `id` carries a sync-ahead record whose chain grew from `base`
+    /// to some version above `above`.
+    #[track_caller]
+    fn assert_sync_chain(&self, id: &ObjectId, base: Version, above: Version) {
+        let record = self
+            .epoch_store
+            .sync_record(id)
+            .unwrap()
+            .expect("a sync-executed write must leave a sync-ahead record");
+        assert_eq!(
+            record.base_version,
+            Some(base),
+            "the record's base must stay the version the chain grew from"
+        );
+        assert!(
+            record.latest_created > above,
+            "the chain head must lie above the consumed version"
+        );
+    }
+
+    /// Asserts the version consumed as `consumed_ref` is sheltered with the
+    /// consumed bytes.
+    #[track_caller]
+    fn assert_sheltered(&self, consumed_ref: ObjectReference) {
+        let digest = consumed_ref.digest;
+        let sheltered = self
+            .epoch_store
+            .sheltered_object(&ObjectKey::from(consumed_ref))
+            .unwrap()
+            .expect("a version consumed by sync execution must be sheltered");
+        assert_eq!(
+            sheltered.digest(),
+            digest,
+            "sheltered bytes must match the consumed version"
+        );
+    }
+
+    #[track_caller]
+    fn assert_not_sheltered(&self, reference: ObjectReference) {
+        assert!(
+            self.epoch_store
+                .sheltered_object(&ObjectKey::from(reference))
+                .unwrap()
+                .is_none(),
+            "a version no sync execution consumed must not be sheltered"
+        );
+    }
+}
+
+#[tokio::test]
+async fn executed_transaction_updates_sync_ahead_bookkeeping() {
+    let (address_1, address_1_key): (Address, AccountPrivateKey) = get_key_pair();
+    let (address_2, address_2_key): (Address, AccountPrivateKey) = get_key_pair();
+    let obj_id = ObjectId::random();
+    let gas1_id = ObjectId::random();
+    let gas2_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![
+            Object::with_id_owner_for_testing(obj_id, address_1),
+            Object::with_id_owner_for_testing(gas1_id, address_1),
+            Object::with_id_owner_for_testing(gas2_id, address_2),
+        ],
+        true,
+    )
+    .await;
+
+    // The first sync-executed transfer consumes the genesis versions: every
+    // written object gets a sync-ahead record based at the version it
+    // consumed, and no handler-latest row.
+    let obj_genesis_ref = s.latest_ref(&obj_id);
+    let gas1_ref = s.latest_ref(&gas1_id);
+    s.transfer(&obj_id, &gas1_id, address_1, &address_1_key, address_2);
+
+    s.assert_sync_chain(&gas1_id, gas1_ref.version, gas1_ref.version);
+    s.assert_sync_chain(&obj_id, obj_genesis_ref.version, obj_genesis_ref.version);
+    assert_eq!(s.epoch_store.handler_latest(&obj_id).unwrap(), None);
+
+    // A second transfer extends the object's chain: the base stays the
+    // version the chain originally grew from while the chain head advances.
+    let obj_v1_ref = s.latest_ref(&obj_id);
+    let gas2_ref = s.latest_ref(&gas2_id);
+    s.transfer(&obj_id, &gas2_id, address_2, &address_2_key, address_1);
+
+    s.assert_sync_chain(&gas2_id, gas2_ref.version, gas2_ref.version);
+    s.assert_sync_chain(&obj_id, obj_genesis_ref.version, obj_v1_ref.version);
+
+    // Both consumed versions are sheltered with their bytes; the live latest
+    // version is not.
+    s.assert_sheltered(obj_genesis_ref);
+    s.assert_sheltered(obj_v1_ref);
+    s.assert_not_sheltered(s.latest_ref(&obj_id));
+}
+
+#[tokio::test]
+async fn handler_known_transaction_writes_handler_latest_only() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let obj_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![
+            Object::with_id_owner_for_testing(obj_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ],
+        true,
+    )
+    .await;
+
+    let obj_genesis_ref = s.latest_ref(&obj_id);
+    let tx = make_transfer_object_transaction(
+        obj_genesis_ref,
+        s.latest_ref(&gas_id),
+        sender,
+        &sender_key,
+        Address::random(),
+        s.rgp,
+    );
+    let tx = s.epoch_store.verify_transaction(tx).unwrap();
+
+    // The handler registered the digest before execution: the hook writes
+    // handler-latest rows and neither sync records nor shelter bytes.
+    s.epoch_store
+        .assign_commit_to_transactions(7, vec![*tx.digest()]);
+    let effects = s.execute(tx);
+
+    let row = s
+        .epoch_store
+        .handler_latest(&obj_id)
+        .unwrap()
+        .expect("a handler-known execution must write a handler-latest row");
+    assert_eq!(row.version, effects.lamport_version());
+    assert_eq!(row.produced_at, 7);
+    assert_eq!(row.kind, HandlerLatestObjectKind::Live);
+
+    assert_eq!(s.epoch_store.sync_record(&obj_id).unwrap(), None);
+    s.assert_not_sheltered(obj_genesis_ref);
+}
+
+#[tokio::test]
+async fn bookkeeping_disabled_writes_nothing() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let obj_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![
+            Object::with_id_owner_for_testing(obj_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ],
+        false,
+    )
+    .await;
+
+    let obj_genesis_ref = s.latest_ref(&obj_id);
+    s.transfer(&obj_id, &gas_id, sender, &sender_key, Address::random());
+
+    assert_eq!(s.epoch_store.handler_latest(&obj_id).unwrap(), None);
+    assert_eq!(s.epoch_store.sync_record(&obj_id).unwrap(), None);
+    s.assert_not_sheltered(obj_genesis_ref);
+}
+
+#[tokio::test]
+async fn sync_ahead_created_object_has_no_base_version() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (created_ref, effects) = s.create_object(&gas_id, sender, &sender_key);
+
+    // `None` marks an id the sync-ahead chain itself created: no named
+    // version of it may answer keep at validation.
+    let record = s
+        .epoch_store
+        .sync_record(created_ref.object_id())
+        .unwrap()
+        .expect("a sync-created object must carry a sync-ahead record");
+    assert_eq!(record.base_version, None);
+    assert_eq!(record.latest_created, effects.lamport_version());
+    s.assert_not_sheltered(created_ref);
+}
+
+#[tokio::test]
+async fn sync_ahead_delete_shelters_the_consumed_version() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (created_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let delete_effects = s.object_basics_call(
+        "delete",
+        vec![CallArg::ImmutableOrOwned(created_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    // The deletion consumes the created version: its bytes are sheltered and
+    // the record's head advances to the tombstone version. The base never
+    // changes once the record exists - it stays `None` because this chain
+    // created the id instead of consuming a pre-existing version.
+    s.assert_sheltered(created_ref);
+    let record = s
+        .epoch_store
+        .sync_record(created_ref.object_id())
+        .unwrap()
+        .expect("a sync-deleted object must keep its sync-ahead record");
+    assert_eq!(record.base_version, None);
+    assert_eq!(record.latest_created, delete_effects.lamport_version());
+
+    // A keyed store read at the delete-tombstone version answers `None`; the
+    // consumed pre-delete bytes are reachable only through the shelter.
+    assert!(
+        s.store_object(created_ref.object_id(), delete_effects.lamport_version())
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn sync_ahead_wrapped_object_is_sheltered_and_reappears_on_unwrap() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (created_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let wrap_effects = s.object_basics_call(
+        "wrap",
+        vec![CallArg::ImmutableOrOwned(created_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    // Wrapping consumes the object's version into the new wrapper: the bytes
+    // are sheltered and the wrapped id's record head advances to the
+    // tombstone version. The wrapper is a new id created by this chain, so
+    // its record starts with `base_version: None`.
+    s.assert_sheltered(created_ref);
+    let wrapped_record = s
+        .epoch_store
+        .sync_record(created_ref.object_id())
+        .unwrap()
+        .expect("a sync-wrapped object must keep its sync-ahead record");
+    assert_eq!(wrapped_record.base_version, None);
+    assert_eq!(
+        wrapped_record.latest_created,
+        wrap_effects.lamport_version()
+    );
+
+    let wrapper_ref = wrap_effects.created()[0].reference;
+    let wrapper_record = s
+        .epoch_store
+        .sync_record(wrapper_ref.object_id())
+        .unwrap()
+        .expect("the wrapper must carry a chain-created sync-ahead record");
+    assert_eq!(wrapper_record.base_version, None);
+
+    // A keyed store read at the wrap-tombstone version answers `None`: the
+    // bytes live only inside the wrapper and, for validation, in the shelter.
+    assert!(
+        s.store_object(created_ref.object_id(), wrap_effects.lamport_version())
+            .is_none()
+    );
+
+    // Unwrapping deletes the wrapper and resurfaces the SAME object id at a
+    // higher version: the id's record extends across the wrap tombstone
+    // (base untouched, head at the unwrap version), the consumed wrapper
+    // version is sheltered, and the live unwrapped version is not.
+    let unwrap_effects = s.object_basics_call(
+        "unwrap",
+        vec![CallArg::ImmutableOrOwned(wrapper_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    let unwrapped_ref = unwrap_effects.unwrapped()[0].reference;
+    assert_eq!(unwrapped_ref.object_id(), created_ref.object_id());
+    assert!(unwrapped_ref.version > created_ref.version);
+
+    let record = s
+        .epoch_store
+        .sync_record(created_ref.object_id())
+        .unwrap()
+        .expect("the unwrapped id must still carry its sync-ahead record");
+    assert_eq!(record.base_version, None);
+    assert_eq!(record.latest_created, unwrap_effects.lamport_version());
+
+    // The wrapper's own chain now ends in its deletion: consumed by the
+    // unwrap, its record head advances to the unwrap version.
+    s.assert_sheltered(wrapper_ref);
+    let wrapper_record = s
+        .epoch_store
+        .sync_record(wrapper_ref.object_id())
+        .unwrap()
+        .expect("the deleted wrapper must keep its sync-ahead record");
+    assert_eq!(wrapper_record.base_version, None);
+    assert_eq!(
+        wrapper_record.latest_created,
+        unwrap_effects.lamport_version()
+    );
+
+    s.assert_not_sheltered(unwrapped_ref);
+
+    // The unwrapped live version answers a keyed store read again.
+    assert!(
+        s.store_object(unwrapped_ref.object_id(), unwrapped_ref.version)
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn sync_ahead_creations_of_every_owner_kind_get_records() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping_with_package("tto", sender, &sender_key, gas_id).await;
+
+    let gas_ref_before = s.latest_ref(&gas_id);
+    let start_effects = s.move_call("M1", "start", vec![], &gas_id, sender, &sender_key);
+
+    // `start` creates an address-owned object, a receivable child, a frozen
+    // object, a shared object, and a dynamic-field child with its `Field`
+    // wrapper. Every creation gets a sync-ahead record with no base,
+    // whatever its owner kind: a sync-created object must answer missing at
+    // validation, never read as pre-epoch state. None is sheltered - nothing
+    // was consumed at these ids.
+    for created in start_effects.created() {
+        let record = s
+            .epoch_store
+            .sync_record(created.reference.object_id())
+            .unwrap()
+            .unwrap_or_else(|| {
+                panic!(
+                    "created object {:?} (owner {:?}) must carry a sync-ahead record",
+                    created.reference.object_id(),
+                    created.owner
+                )
+            });
+        assert_eq!(record.base_version, None, "owner {:?}", created.owner);
+        assert_eq!(record.latest_created, start_effects.lamport_version());
+        s.assert_not_sheltered(created.reference);
+    }
+
+    // The fixture really spans the owner kinds.
+    let owners: Vec<_> = start_effects.created().iter().map(|o| o.owner).collect();
+    assert!(owners.iter().any(|o| matches!(o, Owner::Shared(_))));
+    assert!(owners.iter().any(|o| matches!(o, Owner::Immutable)));
+    assert!(owners.iter().any(|o| matches!(o, Owner::Object(_))));
+    assert!(owners.iter().any(|o| matches!(o, Owner::Address(_))));
+
+    // The gas coin is the only consumed input: its version is sheltered.
+    s.assert_sheltered(gas_ref_before);
+}
+
+#[tokio::test]
+async fn sync_ahead_removed_dynamic_field_shelters_the_runtime_loaded_child() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (parent_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let (value_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+
+    // `add_field` wraps the value into a `Field` child object hanging off the
+    // parent's id; the child is the only creation and is object-owned.
+    let add_effects = s.object_basics_call(
+        "add_field",
+        vec![
+            CallArg::ImmutableOrOwned(parent_ref),
+            CallArg::ImmutableOrOwned(value_ref),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+    let field_ref = add_effects.created()[0].reference;
+    assert!(matches!(add_effects.created()[0].owner, Owner::Object(_)));
+
+    // The field was created, not consumed: nothing to shelter yet.
+    s.assert_not_sheltered(field_ref);
+    let parent_before_remove = s.latest_ref(parent_ref.object_id());
+
+    // `remove_field` declares only the parent (and gas) as inputs: the
+    // `Field` child is loaded at runtime, deleted, and its value unwrapped.
+    // The consumed child version must be sheltered through the store
+    // fallback, and its tombstone version answers no store read.
+    let remove_effects = s.object_basics_call(
+        "remove_field",
+        vec![CallArg::ImmutableOrOwned(parent_before_remove)],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    s.assert_sheltered(field_ref);
+    let field_record = s
+        .epoch_store
+        .sync_record(field_ref.object_id())
+        .unwrap()
+        .expect("the removed field child must carry a sync-ahead record");
+    assert_eq!(field_record.base_version, None);
+    assert_eq!(
+        field_record.latest_created,
+        remove_effects.lamport_version()
+    );
+    assert!(
+        s.store_object(field_ref.object_id(), remove_effects.lamport_version())
+            .is_none()
+    );
+
+    // The parent is a declared input of both steps: its consumed versions are
+    // sheltered through the primary (declared-inputs) leg.
+    s.assert_sheltered(parent_ref);
+    s.assert_sheltered(parent_before_remove);
+    // The value object resurfaces from the field via unwrap: same id, record
+    // head at the remove version.
+    let unwrapped_value = remove_effects.unwrapped()[0].reference;
+    assert_eq!(unwrapped_value.object_id(), value_ref.object_id());
+    let value_record = s
+        .epoch_store
+        .sync_record(value_ref.object_id())
+        .unwrap()
+        .expect("the unwrapped value must carry a sync-ahead record");
+    assert_eq!(
+        value_record.latest_created,
+        remove_effects.lamport_version()
+    );
+}
+
+#[tokio::test]
+async fn sync_ahead_removed_dynamic_object_field_shelters_child_and_wrapper() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (parent_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let (value_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+
+    // `add_ofield` keeps the value a live object: it creates a `Field`
+    // wrapper holding the value's id and re-owns the value object-to-object.
+    let add_effects = s.object_basics_call(
+        "add_ofield",
+        vec![
+            CallArg::ImmutableOrOwned(parent_ref),
+            CallArg::ImmutableOrOwned(value_ref),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+    let field_wrapper_ref = add_effects.created()[0].reference;
+    let value_after_add = add_effects
+        .mutated()
+        .into_iter()
+        .find(|m| m.reference.object_id == *value_ref.object_id())
+        .expect("adding the object field mutates the value object");
+    assert!(matches!(value_after_add.owner, Owner::Object(_)));
+
+    // `remove_ofield` declares only the parent (and gas): BOTH the `Field`
+    // wrapper (deleted) and the value object (mutated back to address-owned)
+    // are loaded at runtime - two consumed versions sheltered through the
+    // store fallback.
+    let remove_effects = s.object_basics_call(
+        "remove_ofield",
+        vec![CallArg::ImmutableOrOwned(
+            s.latest_ref(parent_ref.object_id()),
+        )],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    s.assert_sheltered(field_wrapper_ref);
+    s.assert_sheltered(value_after_add.reference);
+
+    let value_record = s
+        .epoch_store
+        .sync_record(value_ref.object_id())
+        .unwrap()
+        .expect("the removed value object must carry a sync-ahead record");
+    assert_eq!(
+        value_record.latest_created,
+        remove_effects.lamport_version()
+    );
+
+    // The value is live and address-owned again at its new version.
+    let value_now = s.latest_ref(value_ref.object_id());
+    assert_eq!(value_now.version, remove_effects.lamport_version());
+    assert!(
+        s.store_object(value_ref.object_id(), value_now.version)
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn sync_ahead_received_object_is_sheltered_from_the_runtime_load() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping_with_package("tto", sender, &sender_key, gas_id).await;
+
+    let start_effects = s.move_call("M1", "start", vec![], &gas_id, sender, &sender_key);
+    let (parent, child) = parent_and_child(start_effects.created());
+
+    // The receive names the child only as a `Receiving` argument: it is not a
+    // declared input, so execution loads it from the store at runtime and the
+    // hook must fetch the consumed bytes the same way (the store fallback at
+    // the call site). `M1::receiver` transfers the received child onward.
+    let receive_effects = s.move_call(
+        "M1",
+        "receiver",
+        vec![
+            CallArg::ImmutableOrOwned(parent.reference),
+            CallArg::Receiving(child.reference),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    s.assert_sheltered(child.reference);
+    let child_record = s
+        .epoch_store
+        .sync_record(child.reference.object_id())
+        .unwrap()
+        .expect("a received-and-transferred object must carry a sync-ahead record");
+    // The base stays `None`: the child was created by this same sync-ahead
+    // chain (the `start` call), and the receive only extends the chain.
+    assert_eq!(child_record.base_version, None);
+    assert_eq!(
+        child_record.latest_created,
+        receive_effects.lamport_version()
+    );
+
+    // The parent was mutated through its `&mut` argument: a declared input,
+    // consumed and sheltered like any other.
+    s.assert_sheltered(parent.reference);
+    let parent_record = s
+        .epoch_store
+        .sync_record(parent.reference.object_id())
+        .unwrap()
+        .expect("the receiving parent must carry a sync-ahead record");
+    assert_eq!(
+        parent_record.latest_created,
+        receive_effects.lamport_version()
+    );
+}
+
+#[tokio::test]
+async fn sync_ahead_received_then_deleted_object_is_sheltered() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping_with_package("tto", sender, &sender_key, gas_id).await;
+
+    let start_effects = s.move_call("M1", "start", vec![], &gas_id, sender, &sender_key);
+    let (parent, child) = parent_and_child(start_effects.created());
+
+    // `M1::deleter` receives the child and destroys it: the consumed version
+    // is sheltered from the runtime load, the record head advances to the
+    // delete tombstone, and the tombstone version answers no store read.
+    let delete_effects = s.move_call(
+        "M1",
+        "deleter",
+        vec![
+            CallArg::ImmutableOrOwned(parent.reference),
+            CallArg::Receiving(child.reference),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    s.assert_sheltered(child.reference);
+    let child_record = s
+        .epoch_store
+        .sync_record(child.reference.object_id())
+        .unwrap()
+        .expect("a received-and-deleted object must carry a sync-ahead record");
+    assert_eq!(child_record.base_version, None);
+    assert_eq!(
+        child_record.latest_created,
+        delete_effects.lamport_version()
+    );
+    assert!(
+        s.store_object(
+            child.reference.object_id(),
+            delete_effects.lamport_version()
+        )
+        .is_none()
+    );
+}
+
+#[tokio::test]
+async fn read_only_immutable_input_is_not_recorded_or_sheltered() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (mutated_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let (frozen_id_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let freeze_effects = s.object_basics_call(
+        "freeze_object",
+        vec![CallArg::ImmutableOrOwned(frozen_id_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+    let frozen_ref = s.latest_ref(frozen_id_ref.object_id());
+
+    let update_effects = s.object_basics_call(
+        "update",
+        vec![
+            CallArg::ImmutableOrOwned(mutated_ref),
+            CallArg::ImmutableOrOwned(frozen_ref),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    // The read-only immutable input is not consumed: no shelter row, and its
+    // record head stays where the freeze left it. Only the mutated object's
+    // chain advances, sheltering the version the update consumed.
+    s.assert_not_sheltered(frozen_ref);
+    let frozen_record = s
+        .epoch_store
+        .sync_record(frozen_id_ref.object_id())
+        .unwrap()
+        .expect("the freeze itself must have left a sync-ahead record");
+    assert_eq!(
+        frozen_record.latest_created,
+        freeze_effects.lamport_version()
+    );
+
+    s.assert_sheltered(mutated_ref);
+    let mutated_record = s
+        .epoch_store
+        .sync_record(mutated_ref.object_id())
+        .unwrap()
+        .expect("the mutated object must carry a sync-ahead record");
+    assert_eq!(
+        mutated_record.latest_created,
+        update_effects.lamport_version()
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use iota_macros::sim_test;
 use iota_protocol_config::{OverrideGuard, ProtocolConfig};
 use iota_sdk_types::{
-    Address, Command, Identifier, ObjectId, ObjectReference, OwnedObjectReference, Owner,
-    Transaction, TransactionDigest, TransactionEffects, Version,
+    Address, Command, Identifier, ObjectDigest, ObjectId, ObjectReference, OwnedObjectReference,
+    Owner, SharedObjectReference, Transaction, TransactionDigest, TransactionEffects, Version,
 };
 use iota_types::{
     base_types::CommitRound,
@@ -35,9 +35,12 @@ use crate::{
         authority_per_epoch_store::{
             LockDetails,
             consensus_quarantine::ConsensusCommitOutput,
-            handler_object_state::{HandlerLatestObjectKind, SyncAheadRecord},
+            handler_object_state::{
+                HandlerLatestObject, HandlerLatestObjectKind, SyncAheadRecord,
+                handler_latest_upserts,
+            },
         },
-        authority_tests::{TestCallArg, call_move_, init_state_with_objects_and_object_basics},
+        authority_tests::init_state_with_objects_and_object_basics,
         move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
         test_authority_builder::TestAuthorityBuilder,
     },
@@ -2112,6 +2115,22 @@ fn parent_and_child(
         .expect("start() creates a child owned by another created object's id")
 }
 
+/// The arguments of `object_basics::create` for an object owned by `owner`.
+fn create_object_args(owner: Address) -> Vec<CallArg> {
+    vec![
+        CallArg::Pure(bcs::to_bytes(&16u64).unwrap()),
+        CallArg::Pure(bcs::to_bytes(&owner).unwrap()),
+    ]
+}
+
+/// The initial shared version of a shared owner; panics for any other owner.
+fn initial_shared_version(owner: &Owner) -> Version {
+    match owner {
+        Owner::Shared(initial_shared_version) => *initial_shared_version,
+        other => panic!("expected a shared object, got owner {other:?}"),
+    }
+}
+
 impl BookkeepingSetup {
     /// The latest reference of `id` in the authority's view.
     fn latest_ref(&self, id: &ObjectId) -> ObjectReference {
@@ -2138,13 +2157,34 @@ impl BookkeepingSetup {
     /// [`Self::execute`] without asserting execution success, for scenarios
     /// exercising aborted transactions.
     fn execute_unchecked(&self, tx: VerifiedTransaction) -> TransactionEffects {
-        let executable =
-            VerifiedExecutableTransaction::new_from_checkpoint(tx, self.epoch_store.epoch(), 1);
+        self.execute_executable(&self.executable(tx), ExecutionEnv::new())
+    }
+
+    fn executable(&self, tx: VerifiedTransaction) -> VerifiedExecutableTransaction {
+        VerifiedExecutableTransaction::new_from_checkpoint(tx, self.epoch_store.epoch(), 1)
+    }
+
+    fn execute_executable(
+        &self,
+        executable: &VerifiedExecutableTransaction,
+        execution_env: ExecutionEnv,
+    ) -> TransactionEffects {
         let (effects, _) = self
             .authority
-            .try_execute_immediately(&executable, ExecutionEnv::new(), &self.epoch_store)
+            .try_execute_immediately(executable, execution_env, &self.epoch_store)
             .unwrap();
         effects
+    }
+
+    /// The handler-latest row of `id`, which the handler must have written.
+    #[track_caller]
+    fn handler_latest(&self, id: &ObjectId) -> HandlerLatestObject {
+        self.epoch_store
+            .handler_latest(id)
+            .unwrap()
+            .unwrap_or_else(|| {
+                panic!("the handler must have written a handler-latest row for {id}")
+            })
     }
 
     /// Registers `tx`'s digest in the digest -> commit-round map for `round`
@@ -2158,6 +2198,21 @@ impl BookkeepingSetup {
         self.epoch_store
             .assign_commit_to_transactions(round, vec![*tx.digest()]);
         self.execute(tx)
+    }
+
+    /// [`Self::execute_as_handler_known`] of a call into the `object_basics`
+    /// module.
+    fn handler_known_object_basics_call(
+        &self,
+        function: &'static str,
+        args: Vec<CallArg>,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+        round: CommitRound,
+    ) -> TransactionEffects {
+        let tx = self.build_move_call("object_basics", function, args, gas_id, sender, sender_key);
+        self.execute_as_handler_known(tx, round)
     }
 
     /// A verified call into `module::function` of the published test package
@@ -2201,34 +2256,48 @@ impl BookkeepingSetup {
         self.execute(self.build_move_call(module, function, args, gas_id, sender, sender_key))
     }
 
-    /// Builds a call into the `object_basics` module and executes it through
-    /// the certificate + consensus path.
-    async fn shared_object_basics_call(
+    /// Builds a call into the `object_basics` module taking shared-object
+    /// inputs and executes it, with the shared versions assigned directly
+    /// rather than through consensus: the digest never reaches the handler,
+    /// so the hook classifies this execution sync-ahead like every other
+    /// direct execution of the fixture.
+    fn shared_object_basics_call(
         &self,
         function: &'static str,
-        args: Vec<TestCallArg>,
+        args: Vec<CallArg>,
         gas_id: &ObjectId,
         sender: Address,
         sender_key: &AccountPrivateKey,
     ) -> TransactionEffects {
-        let effects = call_move_(
-            &self.authority,
-            None,
-            gas_id,
-            &sender,
-            sender_key,
-            &self.package_id,
-            "object_basics",
-            function,
-            vec![],
-            args,
-            true, // the call takes shared-object inputs
-        )
-        .await
-        .unwrap();
+        let tx = self.build_move_call("object_basics", function, args, gas_id, sender, sender_key);
+        let executable = self.executable(tx);
+        let assigned_versions = self
+            .epoch_store
+            .assign_shared_object_versions_for_tests(
+                self.authority.get_object_cache_reader().as_ref(),
+                std::slice::from_ref(&executable),
+            )
+            .unwrap()
+            .into_map()
+            .remove(&executable.key())
+            .expect("version assignment must cover the transaction it was given");
+        let effects = self.execute_executable(
+            &executable,
+            ExecutionEnv::new().with_assigned_versions(assigned_versions),
+        );
         assert!(effects.status().is_success(), "{:?}", effects.status());
-
         effects
+    }
+
+    /// The argument naming the shared object `id` as a mutable input.
+    fn shared_arg(&self, id: &ObjectId) -> CallArg {
+        let initial_shared_version =
+            initial_shared_version(&self.authority.get_object(id).unwrap().owner);
+        CallArg::Shared(SharedObjectReference::new(
+            *id,
+            initial_shared_version,
+            true,
+        ))
     }
 
     /// [`Self::move_call`] into the `object_basics` module.
@@ -2253,10 +2322,7 @@ impl BookkeepingSetup {
     ) -> (ObjectReference, TransactionEffects) {
         let effects = self.object_basics_call(
             "create",
-            vec![
-                CallArg::Pure(bcs::to_bytes(&16u64).unwrap()),
-                CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
-            ],
+            create_object_args(sender),
             gas_id,
             sender,
             sender_key,
@@ -2411,19 +2477,284 @@ async fn handler_known_transaction_writes_handler_latest_only() {
 
     // The handler registered the digest before execution: the hook writes
     // handler-latest rows and neither sync records nor shelter bytes.
+    let gas_genesis_ref = s.latest_ref(&gas_id);
     let effects = s.execute_as_handler_known(tx, 7);
 
-    let row = s
-        .epoch_store
-        .handler_latest(&obj_id)
-        .unwrap()
-        .expect("a handler-known execution must write a handler-latest row");
-    assert_eq!(row.version, effects.lamport_version());
-    assert_eq!(row.produced_at, 7);
-    assert_eq!(row.kind, HandlerLatestObjectKind::Live);
+    // The gas coin is a written object like any other.
+    for consumed_ref in [obj_genesis_ref, gas_genesis_ref] {
+        let id = consumed_ref.object_id();
+        let row = s.handler_latest(id);
+        assert_eq!(row.version, effects.lamport_version());
+        assert_eq!(row.produced_at, 7);
+        assert_eq!(row.kind, HandlerLatestObjectKind::Live);
 
+        assert_eq!(s.epoch_store.sync_record(id).unwrap(), None);
+        s.assert_not_sheltered(consumed_ref);
+    }
+}
+
+#[tokio::test]
+async fn handler_known_delete_writes_a_deleted_tombstone_row() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let create_effects = s.handler_known_object_basics_call(
+        "create",
+        create_object_args(sender),
+        &gas_id,
+        sender,
+        &sender_key,
+        3,
+    );
+    let created_ref = create_effects.created()[0].reference;
+    assert_eq!(
+        s.handler_latest(created_ref.object_id()).kind,
+        HandlerLatestObjectKind::Live
+    );
+
+    // The deletion in a later commit replaces the live row with a tombstone
+    // at the deletion version, carrying the store's deleted-object digest.
+    let delete_effects = s.handler_known_object_basics_call(
+        "delete",
+        vec![CallArg::ImmutableOrOwned(created_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+        4,
+    );
+    assert_eq!(
+        s.handler_latest(created_ref.object_id()),
+        HandlerLatestObject {
+            version: delete_effects.lamport_version(),
+            digest: ObjectDigest::OBJECT_DELETED,
+            kind: HandlerLatestObjectKind::Deleted,
+            produced_at: 4,
+            initial_shared_version: None,
+        }
+    );
+
+    // Handler-known executions leave no sync-ahead trace, consumed inputs
+    // included.
+    assert_eq!(
+        s.epoch_store.sync_record(created_ref.object_id()).unwrap(),
+        None
+    );
+    s.assert_not_sheltered(created_ref);
+    assert_eq!(s.epoch_store.sync_record(&gas_id).unwrap(), None);
+}
+
+#[tokio::test]
+async fn handler_known_wrap_and_unwrap_move_the_row_through_a_wrapped_tombstone() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (created_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let wrap_effects = s.handler_known_object_basics_call(
+        "wrap",
+        vec![CallArg::ImmutableOrOwned(created_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+        5,
+    );
+    assert_eq!(
+        s.handler_latest(created_ref.object_id()),
+        HandlerLatestObject {
+            version: wrap_effects.lamport_version(),
+            digest: ObjectDigest::OBJECT_WRAPPED,
+            kind: HandlerLatestObjectKind::Wrapped,
+            produced_at: 5,
+            initial_shared_version: None,
+        }
+    );
+    let wrapper_ref = wrap_effects.created()[0].reference;
+    assert_eq!(
+        s.handler_latest(wrapper_ref.object_id()).kind,
+        HandlerLatestObjectKind::Live
+    );
+
+    // Unwrapping resurfaces the id at a higher version: the tombstone gives
+    // way to a live row, and the wrapper's row becomes the tombstone.
+    let unwrap_effects = s.handler_known_object_basics_call(
+        "unwrap",
+        vec![CallArg::ImmutableOrOwned(wrapper_ref)],
+        &gas_id,
+        sender,
+        &sender_key,
+        6,
+    );
+    let unwrapped_ref = unwrap_effects.unwrapped()[0].reference;
+    assert_eq!(unwrapped_ref.object_id(), created_ref.object_id());
+    assert_eq!(
+        s.handler_latest(created_ref.object_id()),
+        HandlerLatestObject {
+            version: unwrapped_ref.version,
+            digest: unwrapped_ref.digest,
+            kind: HandlerLatestObjectKind::Live,
+            produced_at: 6,
+            initial_shared_version: None,
+        }
+    );
+    assert_eq!(
+        s.handler_latest(wrapper_ref.object_id()),
+        HandlerLatestObject {
+            version: unwrap_effects.lamport_version(),
+            digest: ObjectDigest::OBJECT_DELETED,
+            kind: HandlerLatestObjectKind::Deleted,
+            produced_at: 6,
+            initial_shared_version: None,
+        }
+    );
+}
+
+#[tokio::test]
+async fn handler_known_share_records_the_initial_shared_version() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let share_effects =
+        s.handler_known_object_basics_call("share", vec![], &gas_id, sender, &sender_key, 5);
+    let shared = share_effects.created()[0];
+
+    // The creation row doubles as the created-shared flag: it carries the
+    // initial shared version, which the shared-input checks read.
+    assert_eq!(
+        s.handler_latest(shared.reference.object_id()),
+        HandlerLatestObject {
+            version: shared.reference.version,
+            digest: shared.reference.digest,
+            kind: HandlerLatestObjectKind::Live,
+            produced_at: 5,
+            initial_shared_version: Some(initial_shared_version(&shared.owner)),
+        }
+    );
+    assert_eq!(
+        s.epoch_store
+            .sync_record(shared.reference.object_id())
+            .unwrap(),
+        None
+    );
+    s.assert_not_sheltered(shared.reference);
+}
+
+#[tokio::test]
+async fn handler_catching_up_past_sync_execution_replaces_records_with_handler_latest() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let obj_id = ObjectId::random();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![
+            Object::with_id_owner_for_testing(obj_id, sender),
+            Object::with_id_owner_for_testing(gas_id, sender),
+        ],
+        true,
+    )
+    .await;
+
+    // State sync executes the transfer before the handler processes the
+    // commit that kept it.
+    let obj_genesis_ref = s.latest_ref(&obj_id);
+    let gas_genesis_ref = s.latest_ref(&gas_id);
+    let effects = s.transfer(&obj_id, &gas_id, sender, &sender_key, Address::random());
+    let digest = *effects.transaction_digest();
+    s.assert_record(
+        &obj_id,
+        Some(obj_genesis_ref.version),
+        effects.lamport_version(),
+    );
+    assert_eq!(s.epoch_store.handler_latest(&obj_id).unwrap(), None);
+
+    // The handler reaches that commit: it registers the digest (the hook
+    // already ran, so nothing consults the entry) and, with the commit
+    // fully executed, applies the upserts derived from the durable effects.
+    let state = s.epoch_store.handler_object_state_for_testing();
+    s.epoch_store.assign_commit_to_transactions(4, vec![digest]);
+    assert_eq!(state.commit_round_of(&digest), Some(4));
+    s.epoch_store
+        .record_commit_fully_executed(4, &handler_latest_upserts(&effects, 4))
+        .unwrap();
+
+    // Handler-latest rows now answer for every written object, the sync
+    // records whose whole chain the handler passed are gone, and the
+    // commit's map entries are dropped.
+    for id in [&obj_id, &gas_id] {
+        let row = s.handler_latest(id);
+        assert_eq!(row.version, effects.lamport_version());
+        assert_eq!(row.produced_at, 4);
+        assert_eq!(row.kind, HandlerLatestObjectKind::Live);
+        assert_eq!(s.epoch_store.sync_record(id).unwrap(), None);
+    }
+    assert_eq!(state.commit_round_of(&digest), None);
+
+    // The sheltered bytes stay: a crash before this commit's output flushes
+    // replays and re-validates it, so their eviction keys off the flushed
+    // frontier, not off execution completion.
+    s.assert_sheltered(obj_genesis_ref);
+    s.assert_sheltered(gas_genesis_ref);
+}
+
+#[tokio::test]
+async fn handler_catching_up_partway_through_a_chain_keeps_its_sync_record() {
+    let (address_1, address_1_key): (Address, AccountPrivateKey) = get_key_pair();
+    let (address_2, address_2_key): (Address, AccountPrivateKey) = get_key_pair();
+    let obj_id = ObjectId::random();
+    let gas1_id = ObjectId::random();
+    let gas2_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![
+            Object::with_id_owner_for_testing(obj_id, address_1),
+            Object::with_id_owner_for_testing(gas1_id, address_1),
+            Object::with_id_owner_for_testing(gas2_id, address_2),
+        ],
+        true,
+    )
+    .await;
+
+    // Two sync-executed transfers form one chain on the object.
+    let obj_genesis_version = s.latest_ref(&obj_id).version;
+    let first = s.transfer(&obj_id, &gas1_id, address_1, &address_1_key, address_2);
+    let second = s.transfer(&obj_id, &gas2_id, address_2, &address_2_key, address_1);
+    s.assert_record(&obj_id, Some(obj_genesis_version), second.lamport_version());
+
+    // The handler passes only the first commit. The object's record stays -
+    // its chain head is above the handler-written version, so the handler
+    // has not passed the whole chain - while the gas coin's chain, which
+    // ended in that commit, is passed and its record goes.
+    s.epoch_store
+        .assign_commit_to_transactions(4, vec![*first.transaction_digest()]);
+    s.epoch_store
+        .record_commit_fully_executed(4, &handler_latest_upserts(&first, 4))
+        .unwrap();
+    assert_eq!(s.handler_latest(&obj_id).version, first.lamport_version());
+    s.assert_record(&obj_id, Some(obj_genesis_version), second.lamport_version());
+    assert_eq!(s.epoch_store.sync_record(&gas1_id).unwrap(), None);
+
+    // Passing the second commit completes the catch-up.
+    s.epoch_store
+        .assign_commit_to_transactions(5, vec![*second.transaction_digest()]);
+    s.epoch_store
+        .record_commit_fully_executed(5, &handler_latest_upserts(&second, 5))
+        .unwrap();
+    let row = s.handler_latest(&obj_id);
+    assert_eq!(row.version, second.lamport_version());
+    assert_eq!(row.produced_at, 5);
     assert_eq!(s.epoch_store.sync_record(&obj_id).unwrap(), None);
-    s.assert_not_sheltered(obj_genesis_ref);
+    assert_eq!(s.epoch_store.sync_record(&gas2_id).unwrap(), None);
 }
 
 #[tokio::test]
@@ -2840,14 +3171,13 @@ async fn sync_ahead_shared_mutation_writes_nothing_and_deletion_is_recorded() {
     s.shared_object_basics_call(
         "set_value",
         vec![
-            TestCallArg::Object(*shared_ref.object_id()),
-            TestCallArg::Pure(bcs::to_bytes(&42u64).unwrap()),
+            s.shared_arg(shared_ref.object_id()),
+            CallArg::Pure(bcs::to_bytes(&42u64).unwrap()),
         ],
         &gas_id,
         sender,
         &sender_key,
-    )
-    .await;
+    );
     s.assert_record(
         shared_ref.object_id(),
         None,
@@ -2859,15 +3189,13 @@ async fn sync_ahead_shared_mutation_writes_nothing_and_deletion_is_recorded() {
     // facts validation consults - but the consumed shared version is still
     // not sheltered.
     let shared_before_delete = s.latest_ref(shared_ref.object_id());
-    let delete_effects = s
-        .shared_object_basics_call(
-            "delete",
-            vec![TestCallArg::Object(*shared_ref.object_id())],
-            &gas_id,
-            sender,
-            &sender_key,
-        )
-        .await;
+    let delete_effects = s.shared_object_basics_call(
+        "delete",
+        vec![s.shared_arg(shared_ref.object_id())],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
     s.assert_record(
         shared_ref.object_id(),
         None,

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -13,6 +13,7 @@ use iota_sdk_types::{
     Transaction, TransactionDigest, TransactionEffects, Version,
 };
 use iota_types::{
+    base_types::CommitRound,
     crypto::{AccountPrivateKey, get_key_pair},
     effects::TransactionEffectsAPI,
     error::{IotaError, UserInputError},
@@ -32,8 +33,9 @@ use crate::{
     authority::{
         ExecutionEnv,
         authority_per_epoch_store::{
-            LockDetails, consensus_quarantine::ConsensusCommitOutput,
-            handler_object_state::HandlerLatestObjectKind,
+            LockDetails,
+            consensus_quarantine::ConsensusCommitOutput,
+            handler_object_state::{HandlerLatestObjectKind, SyncAheadRecord},
         },
         authority_tests::{TestCallArg, call_move_, init_state_with_objects_and_object_basics},
         move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
@@ -2145,6 +2147,19 @@ impl BookkeepingSetup {
         effects
     }
 
+    /// Registers `tx`'s digest in the digest -> commit-round map for `round`
+    /// before executing - the handler-known classification, under which the
+    /// hook writes handler-latest rows instead of sync-ahead records.
+    fn execute_as_handler_known(
+        &self,
+        tx: VerifiedTransaction,
+        round: CommitRound,
+    ) -> TransactionEffects {
+        self.epoch_store
+            .assign_commit_to_transactions(round, vec![*tx.digest()]);
+        self.execute(tx)
+    }
+
     /// A verified call into `module::function` of the published test package
     /// at the gas coin's latest version.
     fn build_move_call(
@@ -2173,8 +2188,7 @@ impl BookkeepingSetup {
     }
 
     /// Builds a call into `module::function` of the published test package at
-    /// the gas coin's latest version and executes it through the state-sync
-    /// arm.
+    /// the gas coin's latest version and executes it.
     fn move_call(
         &self,
         module: &'static str,
@@ -2188,10 +2202,7 @@ impl BookkeepingSetup {
     }
 
     /// Builds a call into the `object_basics` module and executes it through
-    /// the certificate + consensus path - the only route that assigns
-    /// shared-object input versions in a unit test. The consensus handler
-    /// does not register digests in the round map yet (that wiring is a later
-    /// increment), so the hook still classifies these executions sync-ahead.
+    /// the certificate + consensus path.
     async fn shared_object_basics_call(
         &self,
         function: &'static str,
@@ -2200,7 +2211,7 @@ impl BookkeepingSetup {
         sender: Address,
         sender_key: &AccountPrivateKey,
     ) -> TransactionEffects {
-        call_move_(
+        let effects = call_move_(
             &self.authority,
             None,
             gas_id,
@@ -2214,7 +2225,10 @@ impl BookkeepingSetup {
             true, // the call takes shared-object inputs
         )
         .await
-        .unwrap()
+        .unwrap();
+        assert!(effects.status().is_success(), "{:?}", effects.status());
+
+        effects
     }
 
     /// [`Self::move_call`] into the `object_basics` module.
@@ -2259,7 +2273,7 @@ impl BookkeepingSetup {
         sender: Address,
         sender_key: &AccountPrivateKey,
         recipient: Address,
-    ) {
+    ) -> TransactionEffects {
         let tx = make_transfer_object_transaction(
             self.latest_ref(object_id),
             self.latest_ref(gas_id),
@@ -2268,26 +2282,22 @@ impl BookkeepingSetup {
             recipient,
             self.rgp,
         );
-        self.execute(self.epoch_store.verify_transaction(tx).unwrap());
+        self.execute(self.epoch_store.verify_transaction(tx).unwrap())
     }
 
-    /// Asserts `id` carries a sync-ahead record whose chain grew from `base`
-    /// to some version above `above`.
+    /// Asserts `id`'s sync-ahead record is exactly `{ base_version,
+    /// latest_created }`. `base_version` is the version the chain grew from
+    /// (`None` when the chain itself created the id) and never changes once
+    /// the record exists; `latest_created` is the chain's head.
     #[track_caller]
-    fn assert_sync_chain(&self, id: &ObjectId, base: Version, above: Version) {
-        let record = self
-            .epoch_store
-            .sync_record(id)
-            .unwrap()
-            .expect("a sync-executed write must leave a sync-ahead record");
+    fn assert_record(&self, id: &ObjectId, base_version: Option<Version>, latest_created: Version) {
         assert_eq!(
-            record.base_version,
-            Some(base),
-            "the record's base must stay the version the chain grew from"
-        );
-        assert!(
-            record.latest_created > above,
-            "the chain head must lie above the consumed version"
+            self.epoch_store.sync_record(id).unwrap(),
+            Some(SyncAheadRecord {
+                base_version,
+                latest_created,
+            }),
+            "sync-ahead record mismatch for {id:?}"
         );
     }
 
@@ -2343,20 +2353,28 @@ async fn executed_transaction_updates_sync_ahead_bookkeeping() {
     // consumed, and no handler-latest row.
     let obj_genesis_ref = s.latest_ref(&obj_id);
     let gas1_ref = s.latest_ref(&gas1_id);
-    s.transfer(&obj_id, &gas1_id, address_1, &address_1_key, address_2);
+    let first = s.transfer(&obj_id, &gas1_id, address_1, &address_1_key, address_2);
 
-    s.assert_sync_chain(&gas1_id, gas1_ref.version, gas1_ref.version);
-    s.assert_sync_chain(&obj_id, obj_genesis_ref.version, obj_genesis_ref.version);
+    s.assert_record(&gas1_id, Some(gas1_ref.version), first.lamport_version());
+    s.assert_record(
+        &obj_id,
+        Some(obj_genesis_ref.version),
+        first.lamport_version(),
+    );
     assert_eq!(s.epoch_store.handler_latest(&obj_id).unwrap(), None);
 
     // A second transfer extends the object's chain: the base stays the
     // version the chain originally grew from while the chain head advances.
     let obj_v1_ref = s.latest_ref(&obj_id);
     let gas2_ref = s.latest_ref(&gas2_id);
-    s.transfer(&obj_id, &gas2_id, address_2, &address_2_key, address_1);
+    let second = s.transfer(&obj_id, &gas2_id, address_2, &address_2_key, address_1);
 
-    s.assert_sync_chain(&gas2_id, gas2_ref.version, gas2_ref.version);
-    s.assert_sync_chain(&obj_id, obj_genesis_ref.version, obj_v1_ref.version);
+    s.assert_record(&gas2_id, Some(gas2_ref.version), second.lamport_version());
+    s.assert_record(
+        &obj_id,
+        Some(obj_genesis_ref.version),
+        second.lamport_version(),
+    );
 
     // Both consumed versions are sheltered with their bytes; the live latest
     // version is not.
@@ -2393,9 +2411,7 @@ async fn handler_known_transaction_writes_handler_latest_only() {
 
     // The handler registered the digest before execution: the hook writes
     // handler-latest rows and neither sync records nor shelter bytes.
-    s.epoch_store
-        .assign_commit_to_transactions(7, vec![*tx.digest()]);
-    let effects = s.execute(tx);
+    let effects = s.execute_as_handler_known(tx, 7);
 
     let row = s
         .epoch_store
@@ -2448,13 +2464,7 @@ async fn sync_ahead_created_object_has_no_base_version() {
 
     // `None` marks an id the sync-ahead chain itself created: no named
     // version of it may answer keep at validation.
-    let record = s
-        .epoch_store
-        .sync_record(created_ref.object_id())
-        .unwrap()
-        .expect("a sync-created object must carry a sync-ahead record");
-    assert_eq!(record.base_version, None);
-    assert_eq!(record.latest_created, effects.lamport_version());
+    s.assert_record(created_ref.object_id(), None, effects.lamport_version());
     s.assert_not_sheltered(created_ref);
 }
 
@@ -2483,13 +2493,11 @@ async fn sync_ahead_delete_shelters_the_consumed_version() {
     // changes once the record exists - it stays `None` because this chain
     // created the id instead of consuming a pre-existing version.
     s.assert_sheltered(created_ref);
-    let record = s
-        .epoch_store
-        .sync_record(created_ref.object_id())
-        .unwrap()
-        .expect("a sync-deleted object must keep its sync-ahead record");
-    assert_eq!(record.base_version, None);
-    assert_eq!(record.latest_created, delete_effects.lamport_version());
+    s.assert_record(
+        created_ref.object_id(),
+        None,
+        delete_effects.lamport_version(),
+    );
 
     // A keyed store read at the delete-tombstone version answers `None`; the
     // consumed pre-delete bytes are reachable only through the shelter.
@@ -2524,24 +2532,18 @@ async fn sync_ahead_wrapped_object_is_sheltered_and_reappears_on_unwrap() {
     // tombstone version. The wrapper is a new id created by this chain, so
     // its record starts with `base_version: None`.
     s.assert_sheltered(created_ref);
-    let wrapped_record = s
-        .epoch_store
-        .sync_record(created_ref.object_id())
-        .unwrap()
-        .expect("a sync-wrapped object must keep its sync-ahead record");
-    assert_eq!(wrapped_record.base_version, None);
-    assert_eq!(
-        wrapped_record.latest_created,
-        wrap_effects.lamport_version()
+    s.assert_record(
+        created_ref.object_id(),
+        None,
+        wrap_effects.lamport_version(),
     );
 
     let wrapper_ref = wrap_effects.created()[0].reference;
-    let wrapper_record = s
-        .epoch_store
-        .sync_record(wrapper_ref.object_id())
-        .unwrap()
-        .expect("the wrapper must carry a chain-created sync-ahead record");
-    assert_eq!(wrapper_record.base_version, None);
+    s.assert_record(
+        wrapper_ref.object_id(),
+        None,
+        wrap_effects.lamport_version(),
+    );
 
     // A keyed store read at the wrap-tombstone version answers `None`: the
     // bytes live only inside the wrapper and, for validation, in the shelter.
@@ -2566,26 +2568,19 @@ async fn sync_ahead_wrapped_object_is_sheltered_and_reappears_on_unwrap() {
     assert_eq!(unwrapped_ref.object_id(), created_ref.object_id());
     assert!(unwrapped_ref.version > created_ref.version);
 
-    let record = s
-        .epoch_store
-        .sync_record(created_ref.object_id())
-        .unwrap()
-        .expect("the unwrapped id must still carry its sync-ahead record");
-    assert_eq!(record.base_version, None);
-    assert_eq!(record.latest_created, unwrap_effects.lamport_version());
+    s.assert_record(
+        created_ref.object_id(),
+        None,
+        unwrap_effects.lamport_version(),
+    );
 
     // The wrapper's own chain now ends in its deletion: consumed by the
     // unwrap, its record head advances to the unwrap version.
     s.assert_sheltered(wrapper_ref);
-    let wrapper_record = s
-        .epoch_store
-        .sync_record(wrapper_ref.object_id())
-        .unwrap()
-        .expect("the deleted wrapper must keep its sync-ahead record");
-    assert_eq!(wrapper_record.base_version, None);
-    assert_eq!(
-        wrapper_record.latest_created,
-        unwrap_effects.lamport_version()
+    s.assert_record(
+        wrapper_ref.object_id(),
+        None,
+        unwrap_effects.lamport_version(),
     );
 
     s.assert_not_sheltered(unwrapped_ref);
@@ -2607,25 +2602,24 @@ async fn sync_ahead_creations_of_every_owner_kind_get_records() {
     let start_effects = s.move_call("M1", "start", vec![], &gas_id, sender, &sender_key);
 
     // `start` creates an address-owned object, a receivable child, a frozen
-    // object, a shared object, and a dynamic-field child with its `Field`
+    // object, a shared object, and a dynamic object field child with its `Field`
     // wrapper. Every creation gets a sync-ahead record with no base,
     // whatever its owner kind: a sync-created object must answer missing at
     // validation, never read as pre-epoch state. None is sheltered - nothing
     // was consumed at these ids.
     for created in start_effects.created() {
-        let record = s
-            .epoch_store
-            .sync_record(created.reference.object_id())
-            .unwrap()
-            .unwrap_or_else(|| {
-                panic!(
-                    "created object {:?} (owner {:?}) must carry a sync-ahead record",
-                    created.reference.object_id(),
-                    created.owner
-                )
-            });
-        assert_eq!(record.base_version, None, "owner {:?}", created.owner);
-        assert_eq!(record.latest_created, start_effects.lamport_version());
+        assert_eq!(
+            s.epoch_store
+                .sync_record(created.reference.object_id())
+                .unwrap(),
+            Some(SyncAheadRecord {
+                base_version: None,
+                latest_created: start_effects.lamport_version(),
+            }),
+            "sync-ahead record mismatch for {:?} (owner {:?})",
+            created.reference.object_id(),
+            created.owner
+        );
         s.assert_not_sheltered(created.reference);
     }
 
@@ -2685,15 +2679,10 @@ async fn sync_ahead_removed_dynamic_field_shelters_the_runtime_loaded_child() {
     );
 
     s.assert_sheltered(field_ref);
-    let field_record = s
-        .epoch_store
-        .sync_record(field_ref.object_id())
-        .unwrap()
-        .expect("the removed field child must carry a sync-ahead record");
-    assert_eq!(field_record.base_version, None);
-    assert_eq!(
-        field_record.latest_created,
-        remove_effects.lamport_version()
+    s.assert_record(
+        field_ref.object_id(),
+        None,
+        remove_effects.lamport_version(),
     );
     assert!(
         s.store_object(field_ref.object_id(), remove_effects.lamport_version())
@@ -2708,14 +2697,10 @@ async fn sync_ahead_removed_dynamic_field_shelters_the_runtime_loaded_child() {
     // head at the remove version.
     let unwrapped_value = remove_effects.unwrapped()[0].reference;
     assert_eq!(unwrapped_value.object_id(), value_ref.object_id());
-    let value_record = s
-        .epoch_store
-        .sync_record(value_ref.object_id())
-        .unwrap()
-        .expect("the unwrapped value must carry a sync-ahead record");
-    assert_eq!(
-        value_record.latest_created,
-        remove_effects.lamport_version()
+    s.assert_record(
+        value_ref.object_id(),
+        None,
+        remove_effects.lamport_version(),
     );
 }
 
@@ -2768,15 +2753,10 @@ async fn sync_ahead_removed_dynamic_object_field_shelters_child_and_wrapper() {
 
     s.assert_sheltered(field_wrapper_ref);
     s.assert_sheltered(value_after_add.reference);
-
-    let value_record = s
-        .epoch_store
-        .sync_record(value_ref.object_id())
-        .unwrap()
-        .expect("the removed value object must carry a sync-ahead record");
-    assert_eq!(
-        value_record.latest_created,
-        remove_effects.lamport_version()
+    s.assert_record(
+        value_ref.object_id(),
+        None,
+        remove_effects.lamport_version(),
     );
 
     // The value is live and address-owned again at its new version.
@@ -2813,31 +2793,22 @@ async fn sync_ahead_received_object_is_sheltered_from_the_runtime_load() {
         &sender_key,
     );
 
-    s.assert_sheltered(child.reference);
-    let child_record = s
-        .epoch_store
-        .sync_record(child.reference.object_id())
-        .unwrap()
-        .expect("a received-and-transferred object must carry a sync-ahead record");
     // The base stays `None`: the child was created by this same sync-ahead
     // chain (the `start` call), and the receive only extends the chain.
-    assert_eq!(child_record.base_version, None);
-    assert_eq!(
-        child_record.latest_created,
-        receive_effects.lamport_version()
+    s.assert_sheltered(child.reference);
+    s.assert_record(
+        child.reference.object_id(),
+        None,
+        receive_effects.lamport_version(),
     );
 
     // The parent was mutated through its `&mut` argument: a declared input,
     // consumed and sheltered like any other.
     s.assert_sheltered(parent.reference);
-    let parent_record = s
-        .epoch_store
-        .sync_record(parent.reference.object_id())
-        .unwrap()
-        .expect("the receiving parent must carry a sync-ahead record");
-    assert_eq!(
-        parent_record.latest_created,
-        receive_effects.lamport_version()
+    s.assert_record(
+        parent.reference.object_id(),
+        None,
+        receive_effects.lamport_version(),
     );
 }
 
@@ -2855,13 +2826,11 @@ async fn sync_ahead_shared_mutation_writes_nothing_and_deletion_is_recorded() {
     let share_effects = s.object_basics_call("share", vec![], &gas_id, sender, &sender_key);
     let shared_ref = share_effects.created()[0].reference;
     assert!(matches!(share_effects.created()[0].owner, Owner::Shared(_)));
-    let record = s
-        .epoch_store
-        .sync_record(shared_ref.object_id())
-        .unwrap()
-        .expect("a sync-created shared object must carry a sync-ahead record");
-    assert_eq!(record.base_version, None);
-    assert_eq!(record.latest_created, share_effects.lamport_version());
+    s.assert_record(
+        shared_ref.object_id(),
+        None,
+        share_effects.lamport_version(),
+    );
 
     // Mutating the shared input writes nothing: the record stays where the
     // creation left it (a busy shared object like the Clock would otherwise
@@ -2879,12 +2848,11 @@ async fn sync_ahead_shared_mutation_writes_nothing_and_deletion_is_recorded() {
         &sender_key,
     )
     .await;
-    let record_after_mutation = s
-        .epoch_store
-        .sync_record(shared_ref.object_id())
-        .unwrap()
-        .expect("the mutation must not remove the creation's record");
-    assert_eq!(record_after_mutation, record);
+    s.assert_record(
+        shared_ref.object_id(),
+        None,
+        share_effects.lamport_version(),
+    );
     s.assert_not_sheltered(shared_ref);
 
     // Deleting the shared object IS recorded - deletion is one of the shared
@@ -2900,15 +2868,10 @@ async fn sync_ahead_shared_mutation_writes_nothing_and_deletion_is_recorded() {
             &sender_key,
         )
         .await;
-    let record_after_delete = s
-        .epoch_store
-        .sync_record(shared_ref.object_id())
-        .unwrap()
-        .expect("a sync-deleted shared object must carry a sync-ahead record");
-    assert_eq!(record_after_delete.base_version, None);
-    assert_eq!(
-        record_after_delete.latest_created,
-        delete_effects.lamport_version()
+    s.assert_record(
+        shared_ref.object_id(),
+        None,
+        delete_effects.lamport_version(),
     );
     s.assert_not_sheltered(shared_before_delete);
     assert!(
@@ -2927,6 +2890,7 @@ async fn aborted_transaction_still_records_and_shelters_its_gas() {
     )
     .await;
 
+    let gas_genesis_version = s.latest_ref(&gas_id).version;
     let (parent_ref, _) = s.create_object(&gas_id, sender, &sender_key);
     let gas_before = s.latest_ref(&gas_id);
 
@@ -2946,12 +2910,11 @@ async fn aborted_transaction_still_records_and_shelters_its_gas() {
     // The aborted execution still consumed and rewrote the gas coin: its
     // consumed version is recorded and sheltered like any other write.
     s.assert_sheltered(gas_before);
-    let gas_record = s
-        .epoch_store
-        .sync_record(&gas_id)
-        .unwrap()
-        .expect("the aborted transaction's gas coin must carry a sync-ahead record");
-    assert_eq!(gas_record.latest_created, effects.lamport_version());
+    s.assert_record(
+        &gas_id,
+        Some(gas_genesis_version),
+        effects.lamport_version(),
+    );
 }
 
 #[tokio::test]
@@ -3000,13 +2963,7 @@ async fn smashed_gas_coin_is_recorded_and_sheltered() {
     // deleted - so both versions are recorded and sheltered.
     s.assert_sheltered(gas1_ref);
     s.assert_sheltered(gas2_ref);
-    let smashed_record = s
-        .epoch_store
-        .sync_record(&gas2_id)
-        .unwrap()
-        .expect("the smashed gas coin must carry a sync-ahead record");
-    assert_eq!(smashed_record.base_version, Some(gas2_ref.version));
-    assert_eq!(smashed_record.latest_created, effects.lamport_version());
+    s.assert_record(&gas2_id, Some(gas2_ref.version), effects.lamport_version());
 }
 
 #[tokio::test]
@@ -3020,16 +2977,10 @@ async fn sync_published_package_is_recorded_but_never_sheltered() {
     let s = setup_bookkeeping_with_package("tto", sender, &sender_key, gas_id).await;
 
     // A sync-published package must answer missing at validation - never
-    // read as pre-epoch state - so its creation is recorded; packages are
-    // never sheltered.
+    // read as pre-epoch state - so its creation is recorded. Like any
+    // creation, nothing is sheltered at its id.
     let package_ref = s.latest_ref(&s.package_id);
-    let record = s
-        .epoch_store
-        .sync_record(&s.package_id)
-        .unwrap()
-        .expect("a sync-published package must carry a sync-ahead record");
-    assert_eq!(record.base_version, None);
-    assert_eq!(record.latest_created, package_ref.version);
+    s.assert_record(&s.package_id, None, package_ref.version);
     s.assert_not_sheltered(package_ref);
 }
 
@@ -3065,15 +3016,10 @@ async fn sync_ahead_received_wrapper_is_sheltered_and_unwraps_its_content() {
     // since the inner object's bytes live inside the wrapper's, they are
     // sheltered transitively - the only copy of them on this path.
     s.assert_sheltered(wrapper.reference);
-    let wrapper_record = s
-        .epoch_store
-        .sync_record(wrapper.reference.object_id())
-        .unwrap()
-        .expect("the received-and-deleted wrapper must carry a sync-ahead record");
-    assert_eq!(wrapper_record.base_version, None);
-    assert_eq!(
-        wrapper_record.latest_created,
-        unwrap_effects.lamport_version()
+    s.assert_record(
+        wrapper.reference.object_id(),
+        None,
+        unwrap_effects.lamport_version(),
     );
     assert!(
         s.store_object(
@@ -3087,16 +3033,7 @@ async fn sync_ahead_received_wrapper_is_sheltered_and_unwraps_its_content() {
     // first store row is this version, so its record starts here - no base,
     // nothing sheltered at its id.
     let inner = unwrap_effects.unwrapped()[0].reference;
-    let inner_record = s
-        .epoch_store
-        .sync_record(inner.object_id())
-        .unwrap()
-        .expect("the unwrapped inner object must carry a sync-ahead record");
-    assert_eq!(inner_record.base_version, None);
-    assert_eq!(
-        inner_record.latest_created,
-        unwrap_effects.lamport_version()
-    );
+    s.assert_record(inner.object_id(), None, unwrap_effects.lamport_version());
     s.assert_not_sheltered(inner);
     assert!(s.store_object(inner.object_id(), inner.version).is_some());
 }
@@ -3126,15 +3063,10 @@ async fn sync_ahead_received_then_deleted_object_is_sheltered() {
     );
 
     s.assert_sheltered(child.reference);
-    let child_record = s
-        .epoch_store
-        .sync_record(child.reference.object_id())
-        .unwrap()
-        .expect("a received-and-deleted object must carry a sync-ahead record");
-    assert_eq!(child_record.base_version, None);
-    assert_eq!(
-        child_record.latest_created,
-        delete_effects.lamport_version()
+    s.assert_record(
+        child.reference.object_id(),
+        None,
+        delete_effects.lamport_version(),
     );
     assert!(
         s.store_object(
@@ -3146,7 +3078,7 @@ async fn sync_ahead_received_then_deleted_object_is_sheltered() {
 }
 
 #[tokio::test]
-async fn read_only_immutable_input_is_not_recorded_or_sheltered() {
+async fn immutable_input_read_does_not_extend_record_or_shelter() {
     let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
     let gas_id = ObjectId::random();
 
@@ -3182,25 +3114,17 @@ async fn read_only_immutable_input_is_not_recorded_or_sheltered() {
     // record head stays where the freeze left it. Only the mutated object's
     // chain advances, sheltering the version the update consumed.
     s.assert_not_sheltered(frozen_ref);
-    let frozen_record = s
-        .epoch_store
-        .sync_record(frozen_id_ref.object_id())
-        .unwrap()
-        .expect("the freeze itself must have left a sync-ahead record");
-    assert_eq!(
-        frozen_record.latest_created,
-        freeze_effects.lamport_version()
+    s.assert_record(
+        frozen_id_ref.object_id(),
+        None,
+        freeze_effects.lamport_version(),
     );
 
     s.assert_sheltered(mutated_ref);
-    let mutated_record = s
-        .epoch_store
-        .sync_record(mutated_ref.object_id())
-        .unwrap()
-        .expect("the mutated object must carry a sync-ahead record");
-    assert_eq!(
-        mutated_record.latest_created,
-        update_effects.lamport_version()
+    s.assert_record(
+        mutated_ref.object_id(),
+        None,
+        update_effects.lamport_version(),
     );
 }
 

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -35,7 +35,7 @@ use crate::{
             LockDetails, consensus_quarantine::ConsensusCommitOutput,
             handler_object_state::HandlerLatestObjectKind,
         },
-        authority_tests::init_state_with_objects_and_object_basics,
+        authority_tests::{TestCallArg, call_move_, init_state_with_objects_and_object_basics},
         move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
         test_authority_builder::TestAuthorityBuilder,
     },
@@ -2128,14 +2128,48 @@ impl BookkeepingSetup {
     /// certificate). Unless the digest was registered in the digest ->
     /// commit-round map beforehand, the hook classifies it sync-ahead.
     fn execute(&self, tx: VerifiedTransaction) -> TransactionEffects {
+        let effects = self.execute_unchecked(tx);
+        assert!(effects.status().is_success(), "{:?}", effects.status());
+        effects
+    }
+
+    /// [`Self::execute`] without asserting execution success, for scenarios
+    /// exercising aborted transactions.
+    fn execute_unchecked(&self, tx: VerifiedTransaction) -> TransactionEffects {
         let executable =
             VerifiedExecutableTransaction::new_from_checkpoint(tx, self.epoch_store.epoch(), 1);
         let (effects, _) = self
             .authority
             .try_execute_immediately(&executable, ExecutionEnv::new(), &self.epoch_store)
             .unwrap();
-        assert!(effects.status().is_success(), "{:?}", effects.status());
         effects
+    }
+
+    /// A verified call into `module::function` of the published test package
+    /// at the gas coin's latest version.
+    fn build_move_call(
+        &self,
+        module: &'static str,
+        function: &'static str,
+        args: Vec<CallArg>,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+    ) -> VerifiedTransaction {
+        let tx = Transaction::new_move_call(
+            sender,
+            self.package_id,
+            Identifier::from_static(module),
+            Identifier::from_static(function),
+            vec![],
+            self.latest_ref(gas_id),
+            args,
+            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * self.rgp,
+            self.rgp,
+        )
+        .unwrap();
+        let tx = to_sender_signed_transaction(tx, sender_key);
+        self.epoch_store.verify_transaction(tx).unwrap()
     }
 
     /// Builds a call into `module::function` of the published test package at
@@ -2150,20 +2184,37 @@ impl BookkeepingSetup {
         sender: Address,
         sender_key: &AccountPrivateKey,
     ) -> TransactionEffects {
-        let tx = Transaction::new_move_call(
-            sender,
-            self.package_id,
-            Identifier::from_static(module),
-            Identifier::from_static(function),
+        self.execute(self.build_move_call(module, function, args, gas_id, sender, sender_key))
+    }
+
+    /// Builds a call into the `object_basics` module and executes it through
+    /// the certificate + consensus path - the only route that assigns
+    /// shared-object input versions in a unit test. The consensus handler
+    /// does not register digests in the round map yet (that wiring is a later
+    /// increment), so the hook still classifies these executions sync-ahead.
+    async fn shared_object_basics_call(
+        &self,
+        function: &'static str,
+        args: Vec<TestCallArg>,
+        gas_id: &ObjectId,
+        sender: Address,
+        sender_key: &AccountPrivateKey,
+    ) -> TransactionEffects {
+        call_move_(
+            &self.authority,
+            None,
+            gas_id,
+            &sender,
+            sender_key,
+            &self.package_id,
+            "object_basics",
+            function,
             vec![],
-            self.latest_ref(gas_id),
             args,
-            TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * self.rgp,
-            self.rgp,
+            true, // the call takes shared-object inputs
         )
-        .unwrap();
-        let tx = to_sender_signed_transaction(tx, sender_key);
-        self.execute(self.epoch_store.verify_transaction(tx).unwrap())
+        .await
+        .unwrap()
     }
 
     /// [`Self::move_call`] into the `object_basics` module.
@@ -2788,6 +2839,266 @@ async fn sync_ahead_received_object_is_sheltered_from_the_runtime_load() {
         parent_record.latest_created,
         receive_effects.lamport_version()
     );
+}
+
+#[tokio::test]
+async fn sync_ahead_shared_mutation_writes_nothing_and_deletion_is_recorded() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    // Creating the shared object is recorded like any creation.
+    let share_effects = s.object_basics_call("share", vec![], &gas_id, sender, &sender_key);
+    let shared_ref = share_effects.created()[0].reference;
+    assert!(matches!(share_effects.created()[0].owner, Owner::Shared(_)));
+    let record = s
+        .epoch_store
+        .sync_record(shared_ref.object_id())
+        .unwrap()
+        .expect("a sync-created shared object must carry a sync-ahead record");
+    assert_eq!(record.base_version, None);
+    assert_eq!(record.latest_created, share_effects.lamport_version());
+
+    // Mutating the shared input writes nothing: the record stays where the
+    // creation left it (a busy shared object like the Clock would otherwise
+    // rewrite its record every commit), and shared inputs are never
+    // sheltered. No check consults shared state beyond existence, creation,
+    // and deletion.
+    s.shared_object_basics_call(
+        "set_value",
+        vec![
+            TestCallArg::Object(*shared_ref.object_id()),
+            TestCallArg::Pure(bcs::to_bytes(&42u64).unwrap()),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    )
+    .await;
+    let record_after_mutation = s
+        .epoch_store
+        .sync_record(shared_ref.object_id())
+        .unwrap()
+        .expect("the mutation must not remove the creation's record");
+    assert_eq!(record_after_mutation, record);
+    s.assert_not_sheltered(shared_ref);
+
+    // Deleting the shared object IS recorded - deletion is one of the shared
+    // facts validation consults - but the consumed shared version is still
+    // not sheltered.
+    let shared_before_delete = s.latest_ref(shared_ref.object_id());
+    let delete_effects = s
+        .shared_object_basics_call(
+            "delete",
+            vec![TestCallArg::Object(*shared_ref.object_id())],
+            &gas_id,
+            sender,
+            &sender_key,
+        )
+        .await;
+    let record_after_delete = s
+        .epoch_store
+        .sync_record(shared_ref.object_id())
+        .unwrap()
+        .expect("a sync-deleted shared object must carry a sync-ahead record");
+    assert_eq!(record_after_delete.base_version, None);
+    assert_eq!(
+        record_after_delete.latest_created,
+        delete_effects.lamport_version()
+    );
+    s.assert_not_sheltered(shared_before_delete);
+    assert!(
+        s.store_object(shared_ref.object_id(), delete_effects.lamport_version())
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn aborted_transaction_still_records_and_shelters_its_gas() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![Object::with_id_owner_for_testing(gas_id, sender)],
+        true,
+    )
+    .await;
+
+    let (parent_ref, _) = s.create_object(&gas_id, sender, &sender_key);
+    let gas_before = s.latest_ref(&gas_id);
+
+    // `remove_field` aborts: no field was ever added to the parent.
+    let effects = s.execute_unchecked(s.build_move_call(
+        "object_basics",
+        "remove_field",
+        vec![CallArg::ImmutableOrOwned(
+            s.latest_ref(parent_ref.object_id()),
+        )],
+        &gas_id,
+        sender,
+        &sender_key,
+    ));
+    assert!(!effects.status().is_success());
+
+    // The aborted execution still consumed and rewrote the gas coin: its
+    // consumed version is recorded and sheltered like any other write.
+    s.assert_sheltered(gas_before);
+    let gas_record = s
+        .epoch_store
+        .sync_record(&gas_id)
+        .unwrap()
+        .expect("the aborted transaction's gas coin must carry a sync-ahead record");
+    assert_eq!(gas_record.latest_created, effects.lamport_version());
+}
+
+#[tokio::test]
+async fn smashed_gas_coin_is_recorded_and_sheltered() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas1_id = ObjectId::random();
+    let gas2_id = ObjectId::random();
+    let s = setup_bookkeeping(
+        vec![
+            Object::with_id_owner_for_testing(gas1_id, sender),
+            Object::with_id_owner_for_testing(gas2_id, sender),
+        ],
+        true,
+    )
+    .await;
+
+    let gas1_ref = s.latest_ref(&gas1_id);
+    let gas2_ref = s.latest_ref(&gas2_id);
+
+    // Paying with two coins smashes them: the second is merged into the
+    // first and deleted, without ever being named by a command.
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.command(Command::new_move_call(
+        s.package_id,
+        Identifier::from_static("object_basics"),
+        Identifier::from_static("share"),
+        vec![],
+        vec![],
+    ));
+    let tx = Transaction::new_programmable(
+        sender,
+        vec![gas1_ref, gas2_ref],
+        builder.finish(),
+        TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * s.rgp,
+        s.rgp,
+    );
+    let effects = s.execute(
+        s.epoch_store
+            .verify_transaction(to_sender_signed_transaction(tx, &sender_key))
+            .unwrap(),
+    );
+    assert_eq!(effects.deleted().len(), 1);
+    assert_eq!(effects.deleted()[0].object_id, *gas2_ref.object_id());
+
+    // Both coins were consumed - the survivor mutated, the smashed one
+    // deleted - so both versions are recorded and sheltered.
+    s.assert_sheltered(gas1_ref);
+    s.assert_sheltered(gas2_ref);
+    let smashed_record = s
+        .epoch_store
+        .sync_record(&gas2_id)
+        .unwrap()
+        .expect("the smashed gas coin must carry a sync-ahead record");
+    assert_eq!(smashed_record.base_version, Some(gas2_ref.version));
+    assert_eq!(smashed_record.latest_created, effects.lamport_version());
+}
+
+#[tokio::test]
+async fn sync_published_package_is_recorded_but_never_sheltered() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    // Unlike `setup_bookkeeping` (whose `object_basics` package is inserted
+    // at genesis and thus correctly carries no record), this setup publishes
+    // the package through a real transaction, with the flags on and the
+    // digest unknown to the round map.
+    let s = setup_bookkeeping_with_package("tto", sender, &sender_key, gas_id).await;
+
+    // A sync-published package must answer missing at validation - never
+    // read as pre-epoch state - so its creation is recorded; packages are
+    // never sheltered.
+    let package_ref = s.latest_ref(&s.package_id);
+    let record = s
+        .epoch_store
+        .sync_record(&s.package_id)
+        .unwrap()
+        .expect("a sync-published package must carry a sync-ahead record");
+    assert_eq!(record.base_version, None);
+    assert_eq!(record.latest_created, package_ref.version);
+    s.assert_not_sheltered(package_ref);
+}
+
+#[tokio::test]
+async fn sync_ahead_received_wrapper_is_sheltered_and_unwraps_its_content() {
+    let (sender, sender_key): (Address, AccountPrivateKey) = get_key_pair();
+    let gas_id = ObjectId::random();
+    let s = setup_bookkeeping_with_package("tto", sender, &sender_key, gas_id).await;
+
+    // `M2::start` creates the parent and a receivable wrapper `C { wrapped: B }`.
+    // `B` is created and wrapped within the same transaction, so it never gets
+    // a store row or an effects entry - only the two outer objects appear.
+    let start_effects = s.move_call("M2", "start", vec![], &gas_id, sender, &sender_key);
+    assert_eq!(start_effects.created().len(), 2);
+    let (parent, wrapper) = parent_and_child(start_effects.created());
+
+    // `unwrap_receiver` receives the wrapper (a runtime load - not a declared
+    // input), destructures it, transfers the inner object onward, and deletes
+    // the wrapper's id.
+    let unwrap_effects = s.move_call(
+        "M2",
+        "unwrap_receiver",
+        vec![
+            CallArg::ImmutableOrOwned(parent.reference),
+            CallArg::Receiving(wrapper.reference),
+        ],
+        &gas_id,
+        sender,
+        &sender_key,
+    );
+
+    // The consumed wrapper version is sheltered through the store fallback;
+    // since the inner object's bytes live inside the wrapper's, they are
+    // sheltered transitively - the only copy of them on this path.
+    s.assert_sheltered(wrapper.reference);
+    let wrapper_record = s
+        .epoch_store
+        .sync_record(wrapper.reference.object_id())
+        .unwrap()
+        .expect("the received-and-deleted wrapper must carry a sync-ahead record");
+    assert_eq!(wrapper_record.base_version, None);
+    assert_eq!(
+        wrapper_record.latest_created,
+        unwrap_effects.lamport_version()
+    );
+    assert!(
+        s.store_object(
+            wrapper.reference.object_id(),
+            unwrap_effects.lamport_version()
+        )
+        .is_none()
+    );
+
+    // The inner object surfaces for the first time as `unwrapped`: its very
+    // first store row is this version, so its record starts here - no base,
+    // nothing sheltered at its id.
+    let inner = unwrap_effects.unwrapped()[0].reference;
+    let inner_record = s
+        .epoch_store
+        .sync_record(inner.object_id())
+        .unwrap()
+        .expect("the unwrapped inner object must carry a sync-ahead record");
+    assert_eq!(inner_record.base_version, None);
+    assert_eq!(
+        inner_record.latest_created,
+        unwrap_effects.lamport_version()
+    );
+    s.assert_not_sheltered(inner);
+    assert!(s.store_object(inner.object_id(), inner.version).is_some());
 }
 
 #[tokio::test]

--- a/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
+++ b/crates/iota-core/src/unit_tests/post_consensus_validation_tests.rs
@@ -2358,7 +2358,7 @@ impl BookkeepingSetup {
     #[track_caller]
     fn assert_record(&self, id: &ObjectId, base_version: Option<Version>, latest_created: Version) {
         assert_eq!(
-            self.epoch_store.sync_record(id).unwrap(),
+            self.epoch_store.sync_ahead_record(id).unwrap(),
             Some(SyncAheadRecord {
                 base_version,
                 latest_created,
@@ -2488,7 +2488,7 @@ async fn handler_known_transaction_writes_handler_latest_only() {
         assert_eq!(row.produced_at, 7);
         assert_eq!(row.kind, HandlerLatestObjectKind::Live);
 
-        assert_eq!(s.epoch_store.sync_record(id).unwrap(), None);
+        assert_eq!(s.epoch_store.sync_ahead_record(id).unwrap(), None);
         s.assert_not_sheltered(consumed_ref);
     }
 }
@@ -2541,11 +2541,13 @@ async fn handler_known_delete_writes_a_deleted_tombstone_row() {
     // Handler-known executions leave no sync-ahead trace, consumed inputs
     // included.
     assert_eq!(
-        s.epoch_store.sync_record(created_ref.object_id()).unwrap(),
+        s.epoch_store
+            .sync_ahead_record(created_ref.object_id())
+            .unwrap(),
         None
     );
     s.assert_not_sheltered(created_ref);
-    assert_eq!(s.epoch_store.sync_record(&gas_id).unwrap(), None);
+    assert_eq!(s.epoch_store.sync_ahead_record(&gas_id).unwrap(), None);
 }
 
 #[tokio::test]
@@ -2645,7 +2647,7 @@ async fn handler_known_share_records_the_initial_shared_version() {
     );
     assert_eq!(
         s.epoch_store
-            .sync_record(shared.reference.object_id())
+            .sync_ahead_record(shared.reference.object_id())
             .unwrap(),
         None
     );
@@ -2697,7 +2699,7 @@ async fn handler_catching_up_past_sync_execution_replaces_records_with_handler_l
         assert_eq!(row.version, effects.lamport_version());
         assert_eq!(row.produced_at, 4);
         assert_eq!(row.kind, HandlerLatestObjectKind::Live);
-        assert_eq!(s.epoch_store.sync_record(id).unwrap(), None);
+        assert_eq!(s.epoch_store.sync_ahead_record(id).unwrap(), None);
     }
     assert_eq!(state.commit_round_of(&digest), None);
 
@@ -2742,7 +2744,7 @@ async fn handler_catching_up_partway_through_a_chain_keeps_its_sync_record() {
         .unwrap();
     assert_eq!(s.handler_latest(&obj_id).version, first.lamport_version());
     s.assert_record(&obj_id, Some(obj_genesis_version), second.lamport_version());
-    assert_eq!(s.epoch_store.sync_record(&gas1_id).unwrap(), None);
+    assert_eq!(s.epoch_store.sync_ahead_record(&gas1_id).unwrap(), None);
 
     // Passing the second commit completes the catch-up.
     s.epoch_store
@@ -2753,8 +2755,8 @@ async fn handler_catching_up_partway_through_a_chain_keeps_its_sync_record() {
     let row = s.handler_latest(&obj_id);
     assert_eq!(row.version, second.lamport_version());
     assert_eq!(row.produced_at, 5);
-    assert_eq!(s.epoch_store.sync_record(&obj_id).unwrap(), None);
-    assert_eq!(s.epoch_store.sync_record(&gas2_id).unwrap(), None);
+    assert_eq!(s.epoch_store.sync_ahead_record(&obj_id).unwrap(), None);
+    assert_eq!(s.epoch_store.sync_ahead_record(&gas2_id).unwrap(), None);
 }
 
 #[tokio::test]
@@ -2776,7 +2778,7 @@ async fn bookkeeping_disabled_writes_nothing() {
     s.transfer(&obj_id, &gas_id, sender, &sender_key, Address::random());
 
     assert_eq!(s.epoch_store.handler_latest(&obj_id).unwrap(), None);
-    assert_eq!(s.epoch_store.sync_record(&obj_id).unwrap(), None);
+    assert_eq!(s.epoch_store.sync_ahead_record(&obj_id).unwrap(), None);
     s.assert_not_sheltered(obj_genesis_ref);
 }
 
@@ -2941,7 +2943,7 @@ async fn sync_ahead_creations_of_every_owner_kind_get_records() {
     for created in start_effects.created() {
         assert_eq!(
             s.epoch_store
-                .sync_record(created.reference.object_id())
+                .sync_ahead_record(created.reference.object_id())
                 .unwrap(),
             Some(SyncAheadRecord {
                 base_version: None,


### PR DESCRIPTION
# Description of change

Second increment of deterministic post-consensus validation for P-COOL, stacked on #12845. It wires the execution hook that feeds the bookkeeping introduced there and adds the test suite for it.

- `commit_transaction` records each executed transaction's object writes before the outputs become readable, gated on `pcool_deterministic_validation()`. A transaction of a commit the handler has already processed (its digest is in the round map) upserts handler-latest rows. A transaction only state sync knows yet writes a sync-ahead record for every object it wrote and shelters the bytes of the owned input versions it consumed. Consumed inputs are taken from the declared inputs, with the object store as fallback for runtime-loaded children and received objects.
- Adds the `BookkeepingSetup` fixture and integration tests covering both classifications, the flag-off gate, every write kind and owner kind through real execution, runtime-loaded inputs (dynamic fields, dynamic object fields, receiving), the shared-object lifecycle, aborted transactions, gas smashing, published packages, and the handler-catches-up scenarios that drive `assign_commit_to_transactions` and `record_commit_fully_executed` over already executed transactions.
- Cleanups of the module from #12845 found in its review: the upsert path reads the durable row through the cache, a commit's rows are collapsed to one per id before flush, and `sheltered_object` returns `Object` instead of `Arc<Object>`.

The flag stays off everywhere. With only the hook wired, every execution would be recorded as state sync running ahead of the handler and never cleaned up; the consensus-handler commit-completion signal is the next increment.

## Links to any relevant issues

Related: iotaledger/iota-private#501

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes