### PR TITLE
chore(typed-store): bump rocksdb to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8933,9 +8933,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.3+10.4.2"
+version = "0.19.0+11.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+checksum = "4f45e86edad8e88efe97dbf384b4e48e1ff0f111eabf154c7b09d7a1e5fb573c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -8943,6 +8943,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "rustflags",
  "zstd-sys",
 ]
 
@@ -12349,9 +12350,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+checksum = "d8d90add70d1d420ee487bce4a1449880a8d147451c6051b2ee5f8354553dcbf"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -12473,6 +12474,12 @@ dependencies = [
  "rustc_version",
  "semver",
 ]
+
+[[package]]
+name = "rustflags"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39e0e9135d7a7208ee80aa4e3e4b88f0f5ad7be92153ed70686c38a03db2e63"
 
 [[package]]
 name = "rusticata-macros"

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -18,7 +18,7 @@ fdlimit = "0.2.1"
 hdrhistogram.workspace = true
 num_cpus.workspace = true
 once_cell.workspace = true
-rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf", "bindgen-runtime"] }
+rocksdb = { version = "0.25.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf", "bindgen-runtime"] }
 serde.workspace = true
 sysinfo.workspace = true
 tap.workspace = true


### PR DESCRIPTION
# Description of change

Bumps the `rocksdb` crate in `typed-store` from 0.24 to 0.25.

- Bundled RocksDB engine goes from 10.4.2 to 11.8.1.
- Makes `Options::set_cf_paths` available, which we want for an upcoming storage change.
- No API breakage: no call site in the workspace needed changes.

Build requirement: the vendored engine is now compiled with `-std=c++20` instead of `-std=c++17`, so a C++20 capable compiler is required (the `rust:*` builder images and their `clang` already satisfy this). The crate's own MSRV moves 1.85 -> 1.88, still below our pinned 1.98, so `rust-toolchain.toml` is unchanged.

Kept as a separate PR so the engine bump can be reviewed and rolled back on its own.

## Links to any relevant issues

n/a

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Run locally:

- `cargo check --workspace --all-targets --locked`
- `cargo clippy -p typed-store -p iota-core -p iota-tool --all-targets --all-features -- -D warnings`
- `cargo nextest run -p typed-store` (78 passed)
- `cargo nextest run -p iota-core --lib` filtered to the store/pruner/index tests (23 passed)
- `cargo deny check licenses`

### Release Notes

- [x] Nodes (Validators and Full nodes): Updated the bundled RocksDB engine from 10.4.2 to 11.8.1.
