### PR TITLE
backport: feat(iota-protocol-config): disable Move-based sponsor authentication on mainnet in v34 (#12850)

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -212,6 +212,7 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             activates).
 //             Stop locking immutable objects in post-consensus conflict
 //             resolution.
+//             Disable Move-based sponsor account authentication on mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3362,6 +3363,15 @@ impl ProtocolConfig {
                     // resolution. Set on all chains; inert where the P-COOL flow
                     // is off.
                     cfg.feature_flags.pcool_skip_immutable_object_locks = true;
+
+                    if chain == Chain::Mainnet {
+                        // Disable Move-based sponsor account authentication.
+                        cfg.feature_flags.enable_move_authentication_for_sponsor = false;
+                        // The pre-consensus sponsor-only flag requires
+                        // `enable_move_authentication_for_sponsor`, so clear it too.
+                        cfg.feature_flags
+                            .pre_consensus_sponsor_only_move_authentication = false;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_34.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_34.snap
@@ -37,13 +37,11 @@ feature_flags:
   metadata_in_module_bytes: true
   publish_package_metadata: true
   enable_move_authentication: true
-  enable_move_authentication_for_sponsor: true
   pass_validator_scores_to_advance_epoch: true
   consensus_fast_commit_sync: true
   consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
-  pre_consensus_sponsor_only_move_authentication: true
   always_advance_dkg_to_resolution: true
   pcool_skip_immutable_object_locks: true
   validator_metadata_verify_v2: true


### PR DESCRIPTION
# Description of change

Disables Move-based sponsor account authentication on mainnet at protocol version 34, via the dedicated
`enable_move_authentication_for_sponsor` feature flag.

- The flag (and `pre_consensus_sponsor_only_move_authentication`) were turned on for mainnet in v32; v34 clears both for `Chain::Mainnet` only. Devnet and testnet are unaffected.
- Both flags have to be cleared together: `pre_consensus_sponsor_only_move_authentication()` asserts that `enable_move_authentication_for_sponsor()` is set, so leaving it on would panic on mainnet at v34.
- `enable_move_authentication` (the general flag) is untouched — only the sponsor path is off.

## Links to any relevant issues

N/A

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`cargo test -p iota-protocol-config`: 9 passed, 0 failed. The only snapshot that changed is `Mainnet_version_34`, where the two flags drop out of the serialized output.

### Release Notes

- [x] Protocol: Move-based sponsor account authentication is disabled on mainnet from protocol version 34.
### Release Notes
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->
