### PR TITLE
feat(iota-core): report how far the node is behind in chain time and when it will catch up

### DIFF
--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -73,6 +73,10 @@ struct HistoryExecutionRate {
     rate: f64,
 }
 
+/// How many ticks the rate takes to follow a change in speed, so that the
+/// estimates hold steady while the per-second throughput swings.
+const SMOOTHING_TICKS: f64 = 10.0;
+
 impl HistoryExecutionRate {
     /// Records the timestamp of the newest executed checkpoint at `now` and
     /// returns the updated rate. Returns 0.0 until two ticks with advancing
@@ -101,7 +105,7 @@ impl HistoryExecutionRate {
         self.rate = if self.rate == 0.0 {
             sample
         } else {
-            self.rate * 0.9 + sample * 0.1
+            self.rate * (1.0 - 1.0 / SMOOTHING_TICKS) + sample / SMOOTHING_TICKS
         };
         self.last_wall = Some(now);
         self.last_executed_timestamp_ms = executed_timestamp_ms;

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -95,12 +95,26 @@ impl ChainTimeRate {
 }
 
 /// Wall-clock time to close `behind` while moving through chain time at
-/// `rate`, or `None` when the node is not gaining.
+/// `rate`, or `None` when the node is not gaining, or is gaining so slowly
+/// that the wait is longer than a [`Duration`] can hold.
 ///
 /// Hint: The chain keeps producing a second of history per second, so the gap
 /// closes at whatever `rate` exceeds chain pace by — not at `rate` itself.
 fn time_to_catch_up(behind: Duration, rate: f64) -> Option<Duration> {
-    (rate > 1.0).then(|| Duration::from_secs_f64(behind.as_secs_f64() / (rate - 1.0)))
+    if rate <= 1.0 {
+        return None;
+    }
+    Duration::try_from_secs_f64(behind.as_secs_f64() / (rate - 1.0)).ok()
+}
+
+/// Wall-clock time to reach the end of the current epoch, whose remaining
+/// history is `remaining`, at `rate`. `None` when the rate is not yet known,
+/// or the wait is longer than a [`Duration`] can hold.
+fn time_to_epoch_end(remaining: Duration, rate: f64) -> Option<Duration> {
+    if rate <= 0.0 {
+        return None;
+    }
+    Duration::try_from_secs_f64(remaining.as_secs_f64() / rate).ok()
 }
 
 /// Returns how far behind the node is, how long until the current epoch ends,
@@ -128,13 +142,14 @@ fn sync_eta(
         .get_epoch_info(epoch)
         .ok()
         .flatten()
-        .map(|info| {
+        .and_then(|info| {
             let ends_ms = info
                 .start_timestamp_ms
                 .saturating_add(info.system_state.epoch_duration_ms());
-            let remaining_secs = ends_ms.saturating_sub(chain_ms) as f64 / 1000.0;
-            format_duration(Duration::from_secs_f64(remaining_secs / rate))
+            let remaining = Duration::from_millis(ends_ms.saturating_sub(chain_ms));
+            time_to_epoch_end(remaining, rate)
         })
+        .map(format_duration)
         .unwrap_or_else(|| "unknown".to_string());
 
     let sync_eta = time_to_catch_up(behind, rate)
@@ -403,6 +418,26 @@ mod tests {
         let a_day = Duration::from_secs(86_400);
         assert_eq!(time_to_catch_up(a_day, 2.0), Some(a_day));
         assert_eq!(time_to_catch_up(a_day, 3.0), Some(a_day / 2));
+    }
+
+    /// A rate a hair above chain pace divides by nearly nothing, overflowing
+    /// the `Duration` the estimate is held in. That has to report no estimate
+    /// rather than panic: this runs in the node's logging task, and the
+    /// smoothed rate passes through chain pace whenever a node arrives at or
+    /// falls back from it.
+    #[test]
+    fn a_rate_barely_above_chain_pace_reports_no_estimate() {
+        let behind = Duration::from_secs(658 * 86_400);
+        assert_eq!(time_to_catch_up(behind, 1.0 + f64::EPSILON), None);
+    }
+
+    /// The same overflow reaches the epoch estimate through a rate that has
+    /// barely got going.
+    #[test]
+    fn a_rate_barely_above_zero_reports_no_epoch_estimate() {
+        let remaining = Duration::from_secs(86_400);
+        assert_eq!(time_to_epoch_end(remaining, f64::MIN_POSITIVE), None);
+        assert_eq!(time_to_epoch_end(remaining, 0.0), None);
     }
 
     /// A node moving at chain pace or slower never arrives, so no estimate is

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -61,17 +61,19 @@ fn format_count(count: u64) -> String {
     }
 }
 
-/// Tracks how fast the checkpoints being executed move through the chain's own
-/// timeline, in chain-seconds per wall-clock second, smoothed over recent
-/// ticks.
+/// Tracks how fast the node executes chain history, in seconds of checkpoint
+/// timestamps per wall-clock second.
+///
+/// For example, rate = 376.0 means execution of 376 seconds of history every
+/// real second. A node keeping pace with the chain sits at 1.0.
 #[derive(Default)]
-struct ChainTimeRate {
+struct HistoryExecutionRate {
     last_wall: Option<Instant>,
     last_chain_ms: CheckpointTimestamp,
     rate: f64,
 }
 
-impl ChainTimeRate {
+impl HistoryExecutionRate {
     /// Folds this tick's chain timestamp into the estimate and returns it.
     fn update(&mut self, now: Instant, chain_ms: CheckpointTimestamp) -> f64 {
         if let Some(last_wall) = self.last_wall {
@@ -227,7 +229,7 @@ impl CheckpointProgressTracker {
             let mut prev_total_tx: u64 = 0;
             let mut prev_obj_pruned: u64 = 0;
             let mut prev_ckpt_pruned: u64 = 0;
-            let mut chain_time_rate = ChainTimeRate::default();
+            let mut history_rate = HistoryExecutionRate::default();
 
             loop {
                 interval.tick().await;
@@ -306,7 +308,7 @@ impl CheckpointProgressTracker {
                         String::new()
                     };
 
-                    let rate = chain_time_rate.update(Instant::now(), chain_ms);
+                    let rate = history_rate.update(Instant::now(), chain_ms);
                     let eta =
                         sync_eta(&checkpoint_store, epoch, chain_ms, rate).unwrap_or_default();
 
@@ -366,7 +368,7 @@ mod tests {
     /// checkpoints in a second is moving at 3600x.
     #[test]
     fn the_rate_measures_chain_time_against_wall_time() {
-        let mut rate = ChainTimeRate::default();
+        let mut rate = HistoryExecutionRate::default();
         let start = Instant::now();
         assert_eq!(
             rate.update(start, 0),
@@ -384,7 +386,7 @@ mod tests {
     /// can be made from it.
     #[test]
     fn a_stalled_node_reports_no_rate() {
-        let mut rate = ChainTimeRate::default();
+        let mut rate = HistoryExecutionRate::default();
         let start = Instant::now();
         rate.update(start, 5_000);
         assert_eq!(
@@ -398,7 +400,7 @@ mod tests {
     /// replacing it — otherwise the line would swing with every archive file.
     #[test]
     fn the_rate_is_smoothed_across_ticks() {
-        let mut rate = ChainTimeRate::default();
+        let mut rate = HistoryExecutionRate::default();
         let start = Instant::now();
         rate.update(start, 0);
         let first = rate.update(start + Duration::from_secs(1), 100_000);

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -6,9 +6,13 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+use iota_types::{
+    committee::EpochId, iota_system_state::IotaSystemStateTrait,
+    messages_checkpoint::CheckpointTimestamp,
+};
 use strum::{EnumCount, IntoEnumIterator};
 use tracing::{debug, info};
 
@@ -16,6 +20,132 @@ use crate::{
     authority::authority_store_tables::AuthorityPerpetualTables,
     checkpoints::{CheckpointStore, checkpoint_executor::utils::PipelineStage},
 };
+
+/// The `tracing` target of the progress lines to shorten the log lines.
+const LOG_TARGET: &str = "iota_core::sync";
+
+/// A node whose newest executed checkpoint is within this range is
+/// reported without estimates.
+const CAUGHT_UP_WITHIN: Duration = Duration::from_mins(5);
+
+/// Formats a duration for progress lines, naming its two largest units.
+fn format_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    let (days, hours, minutes, seconds) = (
+        secs / 86400,
+        (secs % 86400) / 3600,
+        (secs % 3600) / 60,
+        secs % 60,
+    );
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+/// Formats a count for progress lines, e.g. "123.4M" or "1.2k".
+fn format_count(count: u64) -> String {
+    if count >= 1_000_000_000 {
+        format!("{:.1}B", count as f64 / 1e9)
+    } else if count >= 1_000_000 {
+        format!("{:.1}M", count as f64 / 1e6)
+    } else if count >= 1_000 {
+        format!("{:.1}k", count as f64 / 1e3)
+    } else {
+        count.to_string()
+    }
+}
+
+/// Tracks how fast the checkpoints being executed move through the chain's own
+/// timeline, in chain-seconds per wall-clock second, smoothed over recent
+/// ticks.
+#[derive(Default)]
+struct ChainTimeRate {
+    last_wall: Option<Instant>,
+    last_chain_ms: CheckpointTimestamp,
+    rate: f64,
+}
+
+impl ChainTimeRate {
+    /// Folds this tick's chain timestamp into the estimate and returns it.
+    fn update(&mut self, now: Instant, chain_ms: CheckpointTimestamp) -> f64 {
+        if let Some(last_wall) = self.last_wall {
+            let wall_secs = now.duration_since(last_wall).as_secs_f64();
+            let chain_secs = chain_ms.saturating_sub(self.last_chain_ms) as f64 / 1000.0;
+            if wall_secs > 0.0 && chain_secs > 0.0 {
+                let sample = chain_secs / wall_secs;
+                // Seeded rather than averaged from zero, so the first line
+                // after a restart reports a usable figure.
+                self.rate = if self.rate == 0.0 {
+                    sample
+                } else {
+                    self.rate * 0.9 + sample * 0.1
+                };
+            }
+        }
+        self.last_wall = Some(now);
+        self.last_chain_ms = chain_ms;
+        self.rate
+    }
+}
+
+/// Wall-clock time to close `behind` while moving through chain time at
+/// `rate`, or `None` when the node is not gaining.
+///
+/// Hint: The chain keeps producing a second of history per second, so the gap
+/// closes at whatever `rate` exceeds chain pace by — not at `rate` itself.
+fn time_to_catch_up(behind: Duration, rate: f64) -> Option<Duration> {
+    (rate > 1.0).then(|| Duration::from_secs_f64(behind.as_secs_f64() / (rate - 1.0)))
+}
+
+/// Returns how far behind the node is, how long until the current epoch ends,
+/// and how long until the node catches up, or `None` when the node is caught up
+/// or not gaining.
+fn sync_eta(
+    checkpoint_store: &CheckpointStore,
+    epoch: EpochId,
+    chain_ms: CheckpointTimestamp,
+    rate: f64,
+) -> Option<String> {
+    if rate <= 0.0 {
+        return None;
+    }
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis() as u64;
+    let behind = Duration::from_millis(now_ms.saturating_sub(chain_ms));
+    if behind < CAUGHT_UP_WITHIN {
+        return None;
+    }
+
+    let epoch_eta = checkpoint_store
+        .get_epoch_info(epoch)
+        .ok()
+        .flatten()
+        .map(|info| {
+            let ends_ms = info
+                .start_timestamp_ms
+                .saturating_add(info.system_state.epoch_duration_ms());
+            let remaining_secs = ends_ms.saturating_sub(chain_ms) as f64 / 1000.0;
+            format_duration(Duration::from_secs_f64(remaining_secs / rate))
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let sync_eta = time_to_catch_up(behind, rate)
+        .map(format_duration)
+        .unwrap_or_else(|| "not gaining".to_string());
+
+    Some(format!(
+        ", {} behind, epoch ETA {epoch_eta}, sync ETA {sync_eta} ({rate:.0}x chain time)",
+        format_duration(behind),
+    ))
+}
 
 /// Shared progress tracker for checkpoint operations. Updated by the
 /// checkpoint executor and pruner, periodically logs a one-line summary.
@@ -82,6 +212,7 @@ impl CheckpointProgressTracker {
             let mut prev_total_tx: u64 = 0;
             let mut prev_obj_pruned: u64 = 0;
             let mut prev_ckpt_pruned: u64 = 0;
+            let mut chain_time_rate = ChainTimeRate::default();
 
             loop {
                 interval.tick().await;
@@ -101,6 +232,10 @@ impl CheckpointProgressTracker {
                 let total_tx = highest_executed_checkpoint
                     .as_ref()
                     .map(|c| c.network_total_transactions)
+                    .unwrap_or(0);
+                let chain_ms = highest_executed_checkpoint
+                    .as_ref()
+                    .map(|c| c.timestamp_ms)
                     .unwrap_or(0);
                 let synced_seq_number = checkpoint_store
                     .get_highest_synced_checkpoint_seq_number()
@@ -144,10 +279,27 @@ impl CheckpointProgressTracker {
                     let checkpoint_prune_time_delta =
                         Duration::from_nanos(checkpoint_prune_time_delta_ns);
 
+                    // Only report pruning when there is some, to avoid cluttering the log
+                    let pruning = if object_prune_delta > 0 || checkpoint_prune_delta > 0 {
+                        format!(
+                            ", objs pruned {object_pruned_seq_number} \
+                             (+{object_prune_delta}, {object_prune_time_delta:.2?}), \
+                             ckpts pruned {checkpoint_pruned_seq_number} \
+                             (+{checkpoint_prune_delta}, {checkpoint_prune_time_delta:.2?})"
+                        )
+                    } else {
+                        String::new()
+                    };
+
+                    let rate = chain_time_rate.update(Instant::now(), chain_ms);
+                    let eta =
+                        sync_eta(&checkpoint_store, epoch, chain_ms, rate).unwrap_or_default();
+
                     info!(
-                        "checkpoint progress [epoch {epoch}]: executed {highest_executed_seq_number}/{synced_seq_number} (+{exec_delta}/+{synced_delta}, {tx_delta} tx/s, {exec_time_delta:.2?}), \
-                         objects pruned {object_pruned_seq_number} (+{object_prune_delta}, {object_prune_time_delta:.2?}), \
-                         checkpoints pruned {checkpoint_pruned_seq_number} (+{checkpoint_prune_delta}, {checkpoint_prune_time_delta:.2?})",
+                        target: LOG_TARGET,
+                        "[epoch {epoch}]: executed {highest_executed_seq_number}/{synced_seq_number} \
+                         (+{exec_delta}/+{synced_delta}, {} tx/s, {exec_time_delta:.2?}){pruning}{eta}",
+                        format_count(tx_delta),
                     );
 
                     // Every pipeline stage admits one checkpoint at a time,
@@ -168,6 +320,7 @@ impl CheckpointProgressTracker {
                         .collect();
                     if !stage_times.is_empty() {
                         debug!(
+                            target: LOG_TARGET,
                             "checkpoint pipeline stage times [epoch {epoch}]: {}",
                             stage_times.join(", ")
                         );
@@ -187,5 +340,93 @@ impl CheckpointProgressTracker {
 impl Default for CheckpointProgressTracker {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rate is chain time over wall time: a tick that covers an hour of
+    /// checkpoints in a second is moving at 3600x.
+    #[test]
+    fn the_rate_measures_chain_time_against_wall_time() {
+        let mut rate = ChainTimeRate::default();
+        let start = Instant::now();
+        assert_eq!(
+            rate.update(start, 0),
+            0.0,
+            "one sample cannot establish a rate"
+        );
+        let sampled = rate.update(start + Duration::from_secs(1), 3_600_000);
+        assert!(
+            (sampled - 3600.0).abs() < 1.0,
+            "an hour of chain time in a wall second is 3600x, got {sampled}"
+        );
+    }
+
+    /// A node whose checkpoints are not advancing has no rate, so no estimate
+    /// can be made from it.
+    #[test]
+    fn a_stalled_node_reports_no_rate() {
+        let mut rate = ChainTimeRate::default();
+        let start = Instant::now();
+        rate.update(start, 5_000);
+        assert_eq!(
+            rate.update(start + Duration::from_secs(1), 5_000),
+            0.0,
+            "chain time that did not move must not produce a rate"
+        );
+    }
+
+    /// The estimate is smoothed, so one slow tick moves it rather than
+    /// replacing it — otherwise the line would swing with every archive file.
+    #[test]
+    fn the_rate_is_smoothed_across_ticks() {
+        let mut rate = ChainTimeRate::default();
+        let start = Instant::now();
+        rate.update(start, 0);
+        let first = rate.update(start + Duration::from_secs(1), 100_000);
+        let second = rate.update(start + Duration::from_secs(2), 100_000 + 1_000);
+        assert!(
+            second < first && second > 10.0,
+            "a single slow tick must pull the estimate down without resetting it, \
+             got {first} then {second}"
+        );
+    }
+
+    /// The gap closes at the margin above chain pace, not at the rate: a node
+    /// at 2x chain time needs a day of wall clock to make up a day, because
+    /// the chain adds another day's worth while it works.
+    #[test]
+    fn catching_up_closes_the_gap_at_the_margin_above_chain_pace() {
+        let a_day = Duration::from_secs(86_400);
+        assert_eq!(time_to_catch_up(a_day, 2.0), Some(a_day));
+        assert_eq!(time_to_catch_up(a_day, 3.0), Some(a_day / 2));
+    }
+
+    /// A node moving at chain pace or slower never arrives, so no estimate is
+    /// offered rather than one that divides by nearly nothing.
+    #[test]
+    fn a_node_at_chain_pace_gets_no_estimate() {
+        let a_day = Duration::from_secs(86_400);
+        assert_eq!(time_to_catch_up(a_day, 1.0), None);
+        assert_eq!(time_to_catch_up(a_day, 0.5), None);
+    }
+
+    #[test]
+    fn format_duration_picks_the_two_largest_units() {
+        assert_eq!(format_duration(Duration::from_secs(45)), "45s");
+        assert_eq!(format_duration(Duration::from_secs(200)), "3m 20s");
+        assert_eq!(format_duration(Duration::from_secs(6120)), "1h 42m");
+        assert_eq!(format_duration(Duration::from_secs(280_800)), "3d 6h");
+    }
+
+    #[test]
+    fn format_count_abbreviates_large_numbers() {
+        assert_eq!(format_count(999), "999");
+        assert_eq!(format_count(1_200), "1.2k");
+        assert_eq!(format_count(123_400_000), "123.4M");
+        assert_eq!(format_count(2_500_000_000), "2.5B");
     }
 }

--- a/crates/iota-core/src/checkpoint_progress_tracker.rs
+++ b/crates/iota-core/src/checkpoint_progress_tracker.rs
@@ -69,29 +69,42 @@ fn format_count(count: u64) -> String {
 #[derive(Default)]
 struct HistoryExecutionRate {
     last_wall: Option<Instant>,
-    last_chain_ms: CheckpointTimestamp,
+    last_executed_timestamp_ms: CheckpointTimestamp,
     rate: f64,
 }
 
 impl HistoryExecutionRate {
-    /// Folds this tick's chain timestamp into the estimate and returns it.
-    fn update(&mut self, now: Instant, chain_ms: CheckpointTimestamp) -> f64 {
-        if let Some(last_wall) = self.last_wall {
-            let wall_secs = now.duration_since(last_wall).as_secs_f64();
-            let chain_secs = chain_ms.saturating_sub(self.last_chain_ms) as f64 / 1000.0;
-            if wall_secs > 0.0 && chain_secs > 0.0 {
-                let sample = chain_secs / wall_secs;
-                // Seeded rather than averaged from zero, so the first line
-                // after a restart reports a usable figure.
-                self.rate = if self.rate == 0.0 {
-                    sample
-                } else {
-                    self.rate * 0.9 + sample * 0.1
-                };
-            }
+    /// Records the timestamp of the newest executed checkpoint at `now` and
+    /// returns the updated rate. Returns 0.0 until two ticks with advancing
+    /// chain time have been seen; a tick whose chain time did not advance
+    /// leaves the estimate unchanged. The estimate follows changes in speed
+    /// gradually over several ticks.
+    fn update(&mut self, now: Instant, executed_timestamp_ms: CheckpointTimestamp) -> f64 {
+        let Some(last_wall) = self.last_wall else {
+            self.last_wall = Some(now);
+            self.last_executed_timestamp_ms = executed_timestamp_ms;
+            return self.rate;
+        };
+        let wall_elapsed_secs = now.duration_since(last_wall).as_secs_f64();
+        let chain_elapsed_secs =
+            executed_timestamp_ms.saturating_sub(self.last_executed_timestamp_ms) as f64 / 1000.0;
+        // Leaving the mark where it is, so that the next tick measures across
+        // the whole stall rather than reading the rate as though it had not
+        // happened.
+        if wall_elapsed_secs <= 0.0 || chain_elapsed_secs <= 0.0 {
+            return self.rate;
         }
+
+        let sample = chain_elapsed_secs / wall_elapsed_secs;
+        // Seeded rather than averaged up from zero, so the first line after a
+        // restart reports a usable figure.
+        self.rate = if self.rate == 0.0 {
+            sample
+        } else {
+            self.rate * 0.9 + sample * 0.1
+        };
         self.last_wall = Some(now);
-        self.last_chain_ms = chain_ms;
+        self.last_executed_timestamp_ms = executed_timestamp_ms;
         self.rate
     }
 }


### PR DESCRIPTION
# Description of change

A node catching up reported how far it had got, but not how long it would take. This adds that to the checkpoint progress line.

All three figures come from one measurement: how fast the executed checkpoints move through the chain's own timeline, in chain-seconds per wall-clock second (`376x` below). Timestamps rather than checkpoint counts, because how many checkpoints an epoch holds is only known once the epoch ends.

- **`behind`** — how far the newest executed checkpoint sits from the present.
- **`epoch ETA`** — chain time left in the epoch, from the `epoch_info` row's start and length, at the current rate.
- **`sync ETA`** — the gap to the present, closed at the rate's *margin above chain pace*. The chain keeps producing a second of history per second, so a node at 2x needs a day of wall clock to make up a day. A node at or below chain pace reports `not gaining` rather than a number that would divide by nearly nothing.
- All three are omitted once the node is within five minutes of the present, where there is nothing left to predict. Minutes rather than seconds because a node syncing from the checkpoint archive follows a feed that is itself published behind the chain.

The line was already wrapping in a maximised terminal before these additions, so it also:

- logs under the `iota_core::sync` target instead of the module path, which is shorter and still under `iota_core`, so a filter on the crate keeps matching it
- abbreviates transaction rates (`7.2k`)
- reports the pruning watermarks only on a tick where one of them moved

Observed on a testnet fullnode syncing from genesis:

```
INFO iota_core::sync: [epoch 32]: executed 11845977/11855877 (+1588/+1644, 7.2k tx/s, 3.94s), objs pruned 11844943 (+2155, 67.06ms), ckpts pruned 11084802 (+2164, 265.16ms), 627d 14h behind, epoch ETA 2m 47s, sync ETA 1d 16h (376x chain time)
```

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Unit tests cover the rate measurement (including a stalled node, which must yield no rate rather than a misleading one), the margin-above-chain-pace arithmetic, and both formatters. Run on a testnet fullnode syncing from genesis, where the rate holds steady while the per-second transaction rate swings by a third.

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): the checkpoint progress log line now reports how far behind the chain a node is, and estimates when it will finish the current epoch and when it will catch up
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
