### PR TITLE
refactor: resolve the attestation verdict in the authority

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -68,7 +68,7 @@ use iota_types::{
         derive_authenticator_function_ref_v1_dynamic_field_id, extract_auth_fun_refs,
         validate_account_object,
     },
-    attestation::{Attestation, AttestationJudge},
+    attestation::Attestation,
     auth_context::AuthContextData,
     base_types::{AuthorityName, ConciseableName, ObjectInfo, ObjectType, VersionNumber},
     committee::{Committee, EpochId, ProtocolVersion},
@@ -1307,7 +1307,6 @@ impl AuthorityState {
                         signer,
                         tx_digest,
                         auth_context_data,
-                        None,
                         &mut None,
                     );
                 (
@@ -2310,9 +2309,9 @@ impl AuthorityState {
             let (
                 inner_temp_store,
                 gas_status,
-                effects,
-                execution_error_opt,
-                _authentication_failed,
+                mut effects,
+                mut execution_error_opt,
+                authentication_failed,
             ) = epoch_store
                 .executor()
                 .authenticate_then_execute_transaction_to_effects(
@@ -2333,11 +2332,25 @@ impl AuthorityState {
                     signer,
                     tx_digest,
                     auth_context_data,
-                    attestation_verdict_context
-                        .as_ref()
-                        .map(|context| context as &dyn AttestationJudge),
                     &mut None,
                 );
+
+            // A failure that refutes the attestation is charged to the
+            // attestor; the issuer's error is kept as the cause. The verdict
+            // only changes the failure status, so the effects the executor
+            // produced are adjusted in place.
+            if authentication_failed
+                && attestation_verdict_context.is_some_and(|context| context.is_refuted())
+            {
+                let mut effects_v1 = effects.into_v1();
+                effects_v1.status =
+                    ExecutionStatus::new_failure(ExecutionErrorKind::InvalidAttestation, None);
+                effects = TransactionEffects::V1(Box::new(effects_v1));
+                execution_error_opt = execution_error_opt.map_err(|error| {
+                    ExecutionError::new_with_source(ExecutionErrorKind::InvalidAttestation, error)
+                });
+            }
+
             (inner_temp_store, gas_status, effects, execution_error_opt)
         };
 

--- a/crates/iota-core/src/authority/attestation_verdict.rs
+++ b/crates/iota-core/src/authority/attestation_verdict.rs
@@ -19,7 +19,7 @@ use iota_types::{
         derive_authenticator_function_ref_v1_dynamic_field_id, extract_auth_fun_refs,
         validate_account_object,
     },
-    attestation::{Attestation, AttestationJudge},
+    attestation::Attestation,
     auth_context::AuthContextData,
     committee::EpochId,
     error::{ExecutionError, ExecutionErrorKind},
@@ -120,8 +120,10 @@ pub(crate) fn executed_versions(
         .collect()
 }
 
-impl AttestationJudge for AttestationVerdictContext<'_> {
-    fn is_refuted(&self) -> bool {
+impl AttestationVerdictContext<'_> {
+    /// Whether the failure refutes the attestation, so it is charged to the
+    /// attestor instead of the issuer.
+    pub(crate) fn is_refuted(&self) -> bool {
         let reauthenticate = should_reauthenticate(
             self.attestation.object_versions(),
             &self.executed_versions,

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -907,7 +907,6 @@ impl LocalExec {
                     tx_info.sender,
                     *tx_digest,
                     auth_context_data,
-                    None,
                     &mut None,
                 );
 
@@ -1223,7 +1222,6 @@ impl LocalExec {
                     signer,
                     *executable.digest(),
                     auth_context_data,
-                    None,
                     &mut None,
                 );
 

--- a/crates/iota-types/src/attestation.rs
+++ b/crates/iota-types/src/attestation.rs
@@ -94,14 +94,6 @@ impl Attestation {
     }
 }
 
-/// Judges an attestation whose transaction failed Move authentication at
-/// execution.
-pub trait AttestationJudge {
-    /// Whether the failure refutes the attestation, so it is charged to the
-    /// attestor instead of the issuer.
-    fn is_refuted(&self) -> bool;
-}
-
 impl AttestedTransaction {
     pub fn new(transaction: Transaction, attestation: Attestation) -> Self {
         Self {

--- a/crates/iota-vm-sdk/src/executor/prepare.rs
+++ b/crates/iota-vm-sdk/src/executor/prepare.rs
@@ -393,7 +393,6 @@ pub(super) fn execute_with_move_authenticators(
             signer,
             transaction.digest(),
             auth_context_data.clone(),
-            None,
             trace_builder_opt,
         );
 

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -28,7 +28,6 @@ mod checked {
         account_abstraction::authenticator_function::{
             AuthenticatorFunctionRef, AuthenticatorFunctionRefV1, MoveAuthenticatorsForExecution,
         },
-        attestation::AttestationJudge,
         auth_context::{AuthContext, AuthContextData},
         balance::{BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME},
         base_types::TxContext,
@@ -309,9 +308,6 @@ mod checked {
         transaction_signer: Address,
         transaction_digest: TransactionDigest,
         auth_context_data: AuthContextData,
-        // Asked, when the authentication of an attested transaction fails,
-        // whether the failure is charged to the attestor.
-        attestation_judge: Option<&dyn AttestationJudge>,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         // VM
@@ -427,16 +423,6 @@ mod checked {
                 report_authentication_error(Err(error), protocol_config)
             }
         };
-
-        // A failure that refutes the attestation is charged to the attestor;
-        // the issuer's error is kept as the cause.
-        let authentication_execution_result =
-            match (authentication_execution_result, attestation_judge) {
-                (Err(error), Some(judge)) if judge.is_refuted() => Err(
-                    ExecutionError::new_with_source(ExecutionErrorKind::InvalidAttestation, error),
-                ),
-                (result, _) => result,
-            };
 
         // TODO: enhance the way the authenticator error is propagated https://github.com/iotaledger/iota/issues/11986
         // Capture whether authentication failed before the result is moved into the

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -12,7 +12,6 @@ use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, MoveAuthenticatorsForExecution,
     },
-    attestation::AttestationJudge,
     auth_context::AuthContextData,
     base_types::TxContext,
     committee::EpochId,
@@ -110,9 +109,6 @@ pub trait Executor {
         transaction_digest: TransactionDigest,
         // BCS-serialized `TransactionData` bytes for the auth context.
         auth_context_data: AuthContextData,
-        // Present for attested transactions: asked, when Move authentication
-        // fails, whether the failure is charged to the attestor.
-        attestation_judge: Option<&dyn AttestationJudge>,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -22,7 +22,6 @@ use iota_types::{
     account_abstraction::authenticator_function::{
         AuthenticatorFunctionRef, MoveAuthenticatorsForExecution,
     },
-    attestation::AttestationJudge,
     auth_context::AuthContextData,
     base_types::TxContext,
     committee::EpochId,
@@ -199,7 +198,6 @@ impl executor::Executor for Executor {
         transaction_signer: Address,
         transaction_digest: TransactionDigest,
         auth_context_data: AuthContextData,
-        attestation_judge: Option<&dyn AttestationJudge>,
         // Tracing
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> (
@@ -225,7 +223,6 @@ impl executor::Executor for Executor {
             transaction_signer,
             transaction_digest,
             auth_context_data,
-            attestation_judge,
             trace_builder_opt,
             &self.0,
         )


### PR DESCRIPTION
# Description 

The adapter no longer asks an AttestationJudge whether a failed Move authentication refutes the attestation. The authority judges after execution, using the authentication-failed flag the executor already returns, and rewrites the failure status of the produced effects to InvalidAttestation when the attestation is refuted. The verdict only changes the failure status, so the effects stay identical otherwise.

This removes the AttestationJudge trait and the re-entrant control flow where the adapter called back into authority code mid-execution.