### PR TITLE
feat(iota-protocol-config): enable dynamic module metadata on mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -222,6 +222,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             config's verifier limits in post-consensus validation, and set
 //             those limits to the node config's defaults on all chains
 //             (inert where the P-COOL flow is off).
+//             Start publishing package metadata using module metadata as a
+//             dynamic field on mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3451,6 +3453,10 @@ impl ProtocolConfig {
                     cfg.max_meter_ticks_per_package = Some(2_200_000);
                     cfg.max_meter_ticks_regex_reference_safety = Some(2_200_000);
                     cfg.feature_flags.pcool_verifier_limits_from_protocol_config = true;
+                    // Publish package metadata with the module metadata stored as a
+                    // dynamic field.
+                    cfg.feature_flags
+                        .package_metadata_with_dynamic_module_metadata = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
@@ -47,6 +47,7 @@ feature_flags:
   pcool_skip_immutable_object_locks: true
   pcool_verifier_limits_from_protocol_config: true
   validator_metadata_verify_v2: true
+  package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true
   max_ptb_value_size_v2: true
   allow_unbounded_system_objects: true


### PR DESCRIPTION
# Description of change

- Enables the `package_metadata_with_dynamic_module_metadata` feature flag on Mainnet in protocol version 35, which turns on publishing package metadata with module metadata as a dynamic field — including Move view function metadata and its verifier checks.
- The flag was enabled on devnet in protocol version 31 and on testnet in protocol version 32.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable package metadata with dynamic module metadata (Move view functions) on Mainnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
