### PR TITLE
fix(iota-core): report a failure to initialize a shared object's next version

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2463,7 +2463,7 @@ impl AuthorityPerEpochStore {
             &[(transaction, effects)],
             self,
             cache_reader,
-        );
+        )?;
         let (_, assigned_versions) = assigned_versions.0.into_iter().next().unwrap();
         Ok(assigned_versions)
     }

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -505,6 +505,7 @@ mod tests {
     use iota_test_transaction_builder::TestTransactionBuilder;
     use iota_types::{
         effects::TestEffectsBuilder,
+        error::IotaError,
         executable_transaction::{
             CertificateProof, ExecutableTransaction, VerifiedExecutableTransaction,
         },
@@ -1110,6 +1111,42 @@ mod tests {
                     vec![VersionAssignment::new(id, Version::from_u64(10)),]
                 ),
             ]
+        );
+    }
+
+    // Initializing a shared object's next version must not fail silently: a
+    // validator that skipped it would initialize the object on a later call,
+    // after these transactions have bumped its version.
+    #[tokio::test]
+    async fn test_assign_versions_from_effects_reports_initialization_failure() {
+        let shared_object = Object::shared_for_testing();
+        let id = shared_object.id();
+        let init_shared_version = shared_object
+            .owner
+            .into_opt_shared()
+            .expect("expected shared object");
+
+        let authority = TestAuthorityBuilder::new()
+            .with_starting_objects(std::slice::from_ref(&shared_object))
+            .build()
+            .await;
+
+        let transaction =
+            generate_shared_objs_tx_with_gas_version(&[(id, init_shared_version, true)], 3);
+        let effects = TestEffectsBuilder::new(transaction.data()).build();
+        let epoch_store = authority.epoch_store_for_testing();
+        // Releasing the epoch tables makes the initialization fail.
+        epoch_store.release_db_handles();
+
+        let result = SharedObjVerManager::assign_versions_from_effects(
+            &[(&transaction, &effects)],
+            &epoch_store,
+            authority.get_object_cache_reader().as_ref(),
+        );
+
+        assert!(
+            matches!(result, Err(IotaError::EpochEnded(_))),
+            "expected the initialization error to be reported, got {result:?}"
         );
     }
 

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -221,26 +221,29 @@ impl SharedObjVerManager {
         })
     }
 
+    /// Returns the shared object versions each transaction was executed with,
+    /// taken from its effects. For a shared object with no
+    /// `next_shared_object_versions` entry yet in this epoch, this also
+    /// initializes one, so it must be called before these transactions are
+    /// executed locally.
     pub fn assign_versions_from_effects(
         transactions_and_effects: &[(&VerifiedExecutableTransaction, &TransactionEffects)],
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
-    ) -> AssignedTxAndVersions {
-        // We don't care about the results since we can use effects to assign versions.
-        // But we must call it to make sure whenever a shared object is touched the
-        // first time during an epoch, either through consensus or through
-        // checkpoint executor, its next version must be initialized. This is
-        // because we initialize the next version of a shared object in an epoch
-        // by reading the current version from the object store. This must be
-        // done before we mutate it the first time, otherwise we would be initializing
-        // it with the wrong version.
-        let _ = get_or_init_versions(
+    ) -> IotaResult<AssignedTxAndVersions> {
+        // The versions returned here are unused - the assignments below come
+        // from the effects. The call is made for its side effect: initializing
+        // each shared object's next version for this epoch from the version the
+        // object holds now. These transactions are about to bump that version,
+        // so an initialization that fails and runs on a later call instead
+        // records a version no other validator counts from.
+        get_or_init_versions(
             transactions_and_effects
                 .iter()
                 .flat_map(|(tx, _)| tx.shared_input_objects()),
             epoch_store,
             cache_reader,
-        );
+        )?;
 
         let mut assigned_versions = Vec::new();
         for (transaction, effects) in transactions_and_effects {
@@ -275,7 +278,7 @@ impl SharedObjVerManager {
             );
             assigned_versions.push((tx_key, tx_assigned_versions));
         }
-        AssignedTxAndVersions::new(assigned_versions)
+        Ok(AssignedTxAndVersions::new(assigned_versions))
     }
 
     pub fn assign_versions_for_transaction(
@@ -1079,7 +1082,8 @@ mod tests {
                 .as_slice(),
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-        );
+        )
+        .unwrap();
         // Check that the shared object's next version is always initialized in the
         // epoch store.
         assert_eq!(
@@ -1187,7 +1191,8 @@ mod tests {
             &[(&transaction, &effects)],
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-        );
+        )
+        .unwrap();
         assert_eq!(
             replay_assignment.0,
             vec![(transaction.key(), expected_assignment)]

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -930,7 +930,7 @@ impl CheckpointExecutor {
                                     effects,
                                     &*self.object_cache_reader,
                                 )
-                                .expect("failed to acquire shared version assignments")
+                                .expect("failed to initialize shared object versions from effects")
                         } else {
                             Default::default()
                         };
@@ -991,7 +991,7 @@ impl CheckpointExecutor {
                 change_epoch_fx,
                 self.object_cache_reader.as_ref(),
             )
-            .expect("Acquiring shared version assignments for change_epoch tx cannot fail");
+            .expect("failed to initialize shared object versions for the change epoch transaction");
 
         info!(
             "scheduling change epoch txn with digest: {:?}, expected effects digest: {:?}, \


### PR DESCRIPTION
# Description of change

### Why

`assign_versions_from_effects` called `get_or_init_versions` only for its side effect and dropped the result, so a failure to initialize a shared object's next version was silent.

The checkpoint executor calls it before it executes a transaction from a synced checkpoint, while the object still holds the version the epoch starts counting from. When that write fails, nothing records it; the failure is silent. A later call initializes the same object from a version that those transactions have already bumped, and every version this validator assigns for that object afterwards differs from the rest of the committee. The validator writes wrong effects and halts on fork detection after the wrong state is already on disk. It takes a failed write to the epoch tables, so it is rare, but nothing else catches it.

This affects both flows, because the consensus handler assigns versions for every transaction in a commit, including ones state sync already executed: under the P-COOL flow, the already-executed check keeps them (Check #1), and in the certificate flow, nothing filters them out.

### Changes

- `assign_versions_from_effects` returns `IotaResult` and propagates the error instead of dropping it.
- `acquire_shared_version_assignments_from_effects` passes it on. Its signature already returned `IotaResult`.
- The checkpoint executor's two call sites keep their existing `expect`, so a failed initialization stops the node.

> [!NOTE]
> No feature flag. When the initialization succeeds, nothing changes: the same entry is written, the same versions are assigned, and the same effects and checkpoints are produced. The only difference is that a failure now stops the node, which produces no state and needs no agreement between validators. Nothing serialized the changes either.

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-private/issues/509. Part of https://github.com/iotaledger/iota-private/issues/502.

## How the change has been tested

```shell
# iota-core: the initialization failure is reported instead of dropped
cargo nextest run -p iota-core -E 'test(test_assign_versions_from_effects_reports_initialization_failure)'
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): A storage failure while initializing a shared object's next version now stops the node instead of being ignored and leaving that node assigning shared object versions that differ from the rest of the committee.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---