### PR TITLE
upstream(iota-framework-snapshot): resolve a snapshot by the newest version at or below the requested one

### DIFF
--- a/crates/iota-framework-snapshot/src/lib.rs
+++ b/crates/iota-framework-snapshot/src/lib.rs
@@ -6,11 +6,12 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
     io::Read,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use iota_framework::SystemPackage;
 pub use iota_framework_snapshot_manifest::*;
+use iota_protocol_config::ProtocolVersion;
 use iota_sdk_types::ObjectId;
 
 const SYSTEM_PACKAGE_PUBLISH_ORDER: &[ObjectId] = &[
@@ -56,19 +57,28 @@ pub fn load_bytecode_snapshot(protocol_version: u64) -> anyhow::Result<Vec<Syste
     Ok(snapshot_objects)
 }
 
-/// Given a protocol version:
-/// * The path to the snapshot directory for that version is returned, if it
-///   exists.
-/// * If the version is greater than the latest snapshot version, then
-///   `Ok(None)` is returned.
-/// * If the version does not exist, but there are snapshots present with
-///   versions greater than `version`, then the smallest snapshot number greater
-///   than `version` is returned.
+/// Returns the path of the snapshot directory holding the framework in effect
+/// at `version`, which is the newest snapshot taken at or before it. A
+/// protocol version that changed nothing in the framework has no snapshot of
+/// its own and resolves to the last one taken before it.
+///
+/// Returns an error if `version` is the max protocol version supported by this
+/// build and no snapshot has been taken for it yet, so that callers fall back
+/// to the framework compiled into this build rather than to an older snapshot.
+/// An error is also returned if `version` predates every snapshot.
 fn snapshot_path_for_version(version: u64) -> anyhow::Result<PathBuf> {
     let snapshot_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bytecode_snapshot");
+    let snapshots = read_snapshot_versions(&snapshot_dir)?;
+    let selected = select_snapshot_version(version, ProtocolVersion::MAX.as_u64(), &snapshots)?;
+
+    Ok(snapshot_dir.join(selected.to_string()))
+}
+
+/// Returns the protocol versions that `snapshot_dir` holds a snapshot for.
+fn read_snapshot_versions(snapshot_dir: &Path) -> anyhow::Result<BTreeSet<u64>> {
     let mut snapshots = BTreeSet::new();
 
-    for entry in fs::read_dir(&snapshot_dir)? {
+    for entry in fs::read_dir(snapshot_dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
@@ -82,9 +92,67 @@ fn snapshot_path_for_version(version: u64) -> anyhow::Result<PathBuf> {
         }
     }
 
+    Ok(snapshots)
+}
+
+/// Picks the newest snapshot taken at or before `version` out of `snapshots`.
+///
+/// `max_protocol_version` never resolves to an earlier snapshot: while it has
+/// no snapshot of its own, the framework in effect at that version is the one
+/// compiled into this build, which is not on disk.
+fn select_snapshot_version(
+    version: u64,
+    max_protocol_version: u64,
+    snapshots: &BTreeSet<u64>,
+) -> anyhow::Result<u64> {
+    if version == max_protocol_version && !snapshots.contains(&version) {
+        anyhow::bail!("No snapshot found for version {version}");
+    }
+
     snapshots
-        .range(version..)
-        .next()
-        .map(|v| snapshot_dir.join(v.to_string()))
+        .range(..=version)
+        .next_back()
+        .copied()
         .ok_or_else(|| anyhow::anyhow!("No snapshot found for version {version}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_snapshot_of_the_requested_version() {
+        let snapshots = BTreeSet::from([1, 2, 3]);
+        assert_eq!(select_snapshot_version(2, 3, &snapshots).unwrap(), 2);
+    }
+
+    #[test]
+    fn select_snapshot_preceding_a_version_without_one() {
+        let snapshots = BTreeSet::from([33, 35]);
+        assert_eq!(select_snapshot_version(34, 36, &snapshots).unwrap(), 33);
+    }
+
+    #[test]
+    fn select_snapshot_of_the_requested_version_past_a_gap() {
+        let snapshots = BTreeSet::from([33, 35]);
+        assert_eq!(select_snapshot_version(35, 36, &snapshots).unwrap(), 35);
+    }
+
+    #[test]
+    fn select_no_snapshot_for_the_max_version_without_one() {
+        let snapshots = BTreeSet::from([33, 35]);
+        assert!(select_snapshot_version(36, 36, &snapshots).is_err());
+    }
+
+    #[test]
+    fn select_snapshot_of_the_max_version_when_it_has_one() {
+        let snapshots = BTreeSet::from([33, 34, 35]);
+        assert_eq!(select_snapshot_version(35, 35, &snapshots).unwrap(), 35);
+    }
+
+    #[test]
+    fn select_no_snapshot_for_a_version_preceding_all_of_them() {
+        let snapshots = BTreeSet::from([10, 11]);
+        assert!(select_snapshot_version(5, 12, &snapshots).is_err());
+    }
 }


### PR DESCRIPTION
# Description of change

Ports the `iota-framework-snapshot` part of [MystenLabs/sui#21460](https://github.com/MystenLabs/sui/pull/21460) ([`24f6a290`](https://github.com/MystenLabs/sui/commit/24f6a290a56c8b81d851c391d7d2766603a25278)). The only part of that commit relevant to us.

- `snapshot_path_for_version` now resolves to the newest snapshot taken **at or below** the requested protocol version, instead of the oldest one at or above it. A version that changed nothing in the framework has no snapshot of its own, so the lookup has to walk backwards; walking forwards returned a framework from a *later* protocol version, which `iota-genesis-builder` would then use to build genesis — valid-looking, but wrong.
- The max protocol version still errors when it has no snapshot yet, so `iota-genesis-builder` keeps falling back to the framework compiled into the build rather than silently picking up an older snapshot. Both halves of the fix are needed together.
- Splits the version arithmetic out of the directory scan (`read_snapshot_versions` / `select_snapshot_version`) so the lookup is unit-testable without a fixture directory, and rewrites the function's doc comment — the old one described the reversed lookup and promised an `Ok(None)` the function never returned.

**No behaviour changes today.** Our snapshot directories are contiguous `1..=35` with `MAX_PROTOCOL_VERSION == 35`, so every version is an exact match and both lookups agree. The gap appears the first time we bump the protocol version without touching Move code under `crates/iota-framework/packages/`, since `iota-framework-snapshot` only ever writes a snapshot for the current max. That is how upstream ended up with holes at 41, 46, 50, 56–57, 59, 61, 63–64, 75 and 77 — and they hit this bug the moment they bumped their max past the newest snapshot. This lands the fix before we grow the first hole.

Two edits from the same upstream hunk are deliberately **not** ported: a `dbg!()` upstream shipped by accident and removed later the same day in an unrelated commit (`5a51d64e12`), and the deletion of the doc comment, rewritten here instead.

## Links to any relevant issues

fixes #10862

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Six unit tests cover `select_snapshot_version`: exact match, a version inside a gap resolving downward, exact match past a gap, the max version with and without a snapshot of its own, and a version predating every snapshot.

Run locally:

- `cargo nextest run -p iota-framework-snapshot` — 10 passed (6 new + the existing compatibility tests)
- `cargo nextest run -p iota-swarm-config -p iota-genesis-builder` — 50 passed; the genesis snapshot tests are unchanged, confirming resolution is identical for versions we do have snapshots for
- `cargo clippy -p iota-framework-snapshot --all-targets -- -D warnings` — clean
