### PR TITLE
chore(ci): count headers resolved before fetch in split-cluster sync check

### DIFF
--- a/scripts/compatibility/split-cluster-sync-check.sh
+++ b/scripts/compatibility/split-cluster-sync-check.sh
@@ -271,6 +271,10 @@ fi
 # Starfish: commit_sync_fetched_commits is labeled by source (commit_sync, fast_commit_sync), so sum across labels
 NODE3_COMMIT_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_fetched_commits")
 NODE3_HEADER_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_synchronizer_fetched_block_headers_by_peer")
+# The live synchronizer waits briefly before fetching and drops headers that
+# arrive through streaming or commit sync meanwhile; on a fast local cluster it
+# may resolve every request this way without sending a single fetch.
+NODE3_HEADER_SYNC_RESOLVED=$(get_metric_value "$METRICS_DIR/node-3-after-join.txt" "consensus_synchronizer_live_block_headers_resolved_before_fetch")
 NODE3_TXN_SYNC=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_transaction_synchronizer_fetched_transactions_by_peer")
 NODE3_COMMIT_SYNC_TXN_SIZE=$(sum_metric_values "$METRICS_DIR/node-3-after-join.txt" "consensus_commit_sync_total_fetched_transactions_size")
 
@@ -278,6 +282,7 @@ echo "Node-3 metrics after initial sync:"
 echo "  last_commit_index: $NODE3_COMMIT_AFTER_JOIN"
 echo "  commit_sync_fetched_commits (sum): $NODE3_COMMIT_SYNC"
 echo "  synchronizer_fetched_block_headers_by_peer (sum): $NODE3_HEADER_SYNC"
+echo "  synchronizer_live_block_headers_resolved_before_fetch: $NODE3_HEADER_SYNC_RESOLVED"
 echo "  commit_sync_total_fetched_transactions_size: $NODE3_COMMIT_SYNC_TXN_SIZE"
 echo "  transaction_synchronizer_fetched_transactions_by_peer (sum): $NODE3_TXN_SYNC"
 
@@ -288,11 +293,12 @@ else
   echo "✓ Node-3 caught up past initial commit index"
 fi
 
-# Check 2: Header synchronizer was active
-if [ "$NODE3_HEADER_SYNC" -le 0 ]; then
-  FAILURES+=("FAIL: Header synchronizer was not active (consensus_synchronizer_fetched_block_headers_by_peer = $NODE3_HEADER_SYNC)")
+# Check 2: Header synchronizer was active, either fetching missing headers or
+# resolving them before the fetch went out
+if [ "$NODE3_HEADER_SYNC" -le 0 ] && [ "$NODE3_HEADER_SYNC_RESOLVED" -le 0 ]; then
+  FAILURES+=("FAIL: Header synchronizer was not active (consensus_synchronizer_fetched_block_headers_by_peer = $NODE3_HEADER_SYNC, consensus_synchronizer_live_block_headers_resolved_before_fetch = $NODE3_HEADER_SYNC_RESOLVED)")
 else
-  echo "✓ Header synchronizer was active (fetched $NODE3_HEADER_SYNC block headers)"
+  echo "✓ Header synchronizer was active (fetched $NODE3_HEADER_SYNC block headers, resolved $NODE3_HEADER_SYNC_RESOLVED before fetch)"
 fi
 
 # Check 3: Commit syncer was active


### PR DESCRIPTION
# Description of change

The split-cluster sync check asserted that the late-joining candidate node fetched at least one block header through the header synchronizer. Since #12844 the live synchronizer waits before fetching and skips headers that arrive through streaming or commit sync meanwhile, so on the local four-node cluster every live request is resolved without a fetch and the merge-queue run fails on an idle counter.

- Treat the header synchronizer as active when it either fetched headers or resolved them before the fetch went out.
- Print and report both counters so a future failure shows which side was silent.

## Links to any relevant issues

Fixes #12865

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
