### PR TITLE
chore(iota-types): adopt the SDK deny-rule object mirrors from iota-sdk-move-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,8 +1836,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -7686,6 +7686,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-sdk-move-types"
+version = "1.0.0-beta.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8ae07b2897331e313b4231cafe1add6327511fa1#8ae07b2897331e313b4231cafe1add6327511fa1"
+dependencies = [
+ "bcs",
+ "filetime",
+ "iota-sdk-types",
+ "paste",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "iota-sdk-transaction-builder"
 version = "1.0.0-beta.1"
 source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=8ae07b2897331e313b4231cafe1add6327511fa1#8ae07b2897331e313b4231cafe1add6327511fa1"
@@ -8246,6 +8259,7 @@ dependencies = [
  "iota-multiaddr",
  "iota-protocol-config",
  "iota-sdk-crypto",
+ "iota-sdk-move-types",
  "iota-sdk-types",
  "itertools 0.13.0",
  "lru 0.12.4",
@@ -11640,7 +11654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -11674,7 +11688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14929,7 +14943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.6",
  "static_assertions",
 ]
 

--- a/crates/iota-types/Cargo.toml
+++ b/crates/iota-types/Cargo.toml
@@ -27,6 +27,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 futures.workspace = true
 hex.workspace = true
 indexmap.workspace = true
+iota-sdk-move-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "8ae07b2897331e313b4231cafe1add6327511fa1", features = ["serde"], default-features = false }
 itertools.workspace = true
 lru.workspace = true
 nonempty.workspace = true

--- a/crates/iota-types/src/collection_types.rs
+++ b/crates/iota-types/src/collection_types.rs
@@ -59,34 +59,6 @@ impl Default for Table {
     }
 }
 
-/// Rust version of the Move iota::linked_table::LinkedTable type.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct LinkedTable<K> {
-    pub id: ObjectId,
-    pub size: u64,
-    pub head: Option<K>,
-    pub tail: Option<K>,
-}
-
-impl<K> Default for LinkedTable<K> {
-    fn default() -> Self {
-        LinkedTable {
-            id: ObjectId::ZERO,
-            size: 0,
-            head: None,
-            tail: None,
-        }
-    }
-}
-
-/// Rust version of the Move iota::linked_table::Node type.
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct LinkedTableNode<K, V> {
-    pub prev: Option<K>,
-    pub next: Option<K>,
-    pub value: V,
-}
-
 /// Rust version of the Move iota::bag::Bag type.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Bag {

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -265,6 +265,12 @@ impl MoveTypeTagTrait for Address {
     }
 }
 
+impl MoveTypeTagTrait for iota_sdk_move_types::iota_framework::object::ID {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Struct(Box::new(StructTag::new_id()))
+    }
+}
+
 impl<T: MoveTypeTagTrait> MoveTypeTagTrait for Vec<T> {
     fn get_type_tag() -> TypeTag {
         TypeTag::Vector(Box::new(T::get_type_tag()))

--- a/crates/iota-types/src/transaction_deny_rules.rs
+++ b/crates/iota-types/src/transaction_deny_rules.rs
@@ -3,18 +3,19 @@
 
 use std::fmt;
 
-use iota_sdk_types::{Address, DenyRuleSet, Identifier, Version};
+use iota_sdk_move_types::iota_framework::linked_table::{LinkedTable, Node};
+pub use iota_sdk_move_types::iota_framework::transaction_deny_rules::{
+    TransactionDenyRules, TransactionDenyRulesInnerV1,
+};
+use iota_sdk_types::{DenyRuleSet, Identifier, Version};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS, IOTA_TRANSACTION_DENY_RULES_OBJECT_ID, MoveTypeTagTrait,
-    collection_types::{LinkedTable, LinkedTableNode},
     dynamic_field::get_dynamic_field_from_store,
     error::{IotaError, IotaResult},
-    id::{ID, UID},
     storage::ObjectStore,
-    versioned::Versioned,
 };
 
 pub const TRANSACTION_DENY_RULES_MODULE_NAME: &IdentStr = ident_str!("transaction_deny_rules");
@@ -30,9 +31,9 @@ pub const RESOLVED_IOTA_TRANSACTION_DENY_RULES: (&AccountAddress, &IdentStr, &Id
     ident_str!("TransactionDenyRules"),
 );
 
-/// The initial shared version of the `TransactionDenyRules` object, or `None`
-/// while the object has not been created yet (the
-/// `TransactionDenyRulesCreate` end-of-epoch transaction has not run).
+/// The initial shared version of the `TransactionDenyRules` object. Returns
+/// `None` while the `TransactionDenyRulesCreate` end-of-epoch transaction has
+/// not created the object yet.
 ///
 /// # Panics
 ///
@@ -52,35 +53,11 @@ pub fn get_transaction_deny_rules_obj_initial_shared_version(
 
 pub const TRANSACTION_DENY_RULES_INNER_V1: u64 = 1;
 
-/// Rust version of the Move `transaction_deny_rules::TransactionDenyRules`
-/// type.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TransactionDenyRules {
-    pub id: UID,
-    pub inner: Versioned,
-}
-
-/// Rust version of the Move
-/// `transaction_deny_rules::TransactionDenyRulesInnerV1` type.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TransactionDenyRulesInnerV1 {
-    pub version: u64,
-    pub denied_addresses: LinkedTable<Address>,
-    pub denied_objects: LinkedTable<ID>,
-    pub denied_packages: LinkedTable<ID>,
-    pub package_publish_disabled: bool,
-    pub package_upgrade_disabled: bool,
-    pub shared_object_disabled: bool,
-    pub user_transaction_disabled: bool,
-    pub receiving_objects_disabled: bool,
-    pub move_authenticator_disabled: bool,
-}
-
-/// The full deny rule state read back from the `TransactionDenyRules` object,
-/// or `None` while the object has not been created yet.
+/// The full deny rule state read back from the `TransactionDenyRules` object.
+/// Returns `None` while the object has not been created yet.
 ///
-/// Each deny list is reconstructed by walking its `LinkedTable` (`head` →
-/// `node.next`) with derived-id child reads, so any node can rebuild the
+/// Each deny list is reconstructed by walking its `LinkedTable` from `head`
+/// through `node.next` with derived-id child reads. Any node can rebuild the
 /// state from its object store alone. Validators seed enforcement and the
 /// mirrored on-chain state from this at epoch start.
 pub fn get_transaction_deny_rules(
@@ -132,29 +109,29 @@ pub fn get_transaction_deny_rules(
 }
 
 /// Collects a `LinkedTable`'s keys in list order by following the `next`
-/// links, one derived-id child read per entry.
+/// links. Each entry costs one derived-id child read.
 fn walk_linked_table<K>(
     object_store: &dyn ObjectStore,
-    table: &LinkedTable<K>,
+    table: &LinkedTable<K, bool>,
 ) -> IotaResult<Vec<K>>
 where
     K: MoveTypeTagTrait + Serialize + DeserializeOwned + Clone + fmt::Debug,
 {
+    let table_id = table.id.id.bytes;
     let mut keys = Vec::with_capacity(table.size as usize);
     let mut next = table.head.clone();
     while let Some(key) = next {
-        // A cycle in the links would otherwise never terminate; the walk can
-        // only visit `size` distinct entries.
+        // A cycle in the links would otherwise never terminate. The walk
+        // visits at most `size` entries.
         if keys.len() as u64 == table.size {
             return Err(IotaError::ObjectDeserialization {
                 error: format!(
                     "LinkedTable {} has more linked entries than its size {}",
-                    table.id, table.size
+                    table_id, table.size
                 ),
             });
         }
-        let node: LinkedTableNode<K, bool> =
-            get_dynamic_field_from_store(object_store, table.id, &key)?;
+        let node: Node<K, bool> = get_dynamic_field_from_store(object_store, table_id, &key)?;
         keys.push(key);
         next = node.next;
     }
@@ -162,7 +139,7 @@ where
         return Err(IotaError::ObjectDeserialization {
             error: format!(
                 "LinkedTable {} links {} entries but its size is {}",
-                table.id,
+                table_id,
                 keys.len(),
                 table.size
             ),


### PR DESCRIPTION
# Description of change

The node's copies of the `TransactionDenyRules` object mirrors are replaced by the SDK types from `iota-sdk-move-types`. The SDK already carries them with shape checks against the compiled module, so the hand-rolled versions were a duplicate that could drift.

- Add `iota-sdk-move-types` as a pinned workspace dependency at the existing SDK rev.
- Delete the hand-rolled `TransactionDenyRules` and `TransactionDenyRulesInnerV1` mirrors in `iota-types`. The SDK types are re-exported at the same path.
- Adapt the object walker to the SDK `LinkedTable<K, V>` and `Node<K, V>` shapes.
- Add a `MoveTypeTagTrait` impl for the SDK `object::ID` so it can key dynamic-field reads.
- Drop the now unused `LinkedTable` and `LinkedTableNode` mirrors from `collection_types`.

No behavior change. The mirrors are node-internal decoding types only.

## Links to any relevant issues

fixes #12613

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Deny-rule unit tests 24/24, deny-rule simtest battery 21/21, clippy and fmt clean. No new tests: the existing batteries exercise the walker end to end.

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->

---
