### PR TITLE
feat(iota-protocol-config): enable StarfishSpeed on mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -216,6 +216,8 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 // Version 35: Scale the PTB value size limit by the value's type.
 //             Allow objects created or mutated by system transactions to exceed
 //             the max object size limit.
+//             Enable the optimistic commit rule (StarfishSpeed) in Starfish
+//             consensus on mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3397,6 +3399,9 @@ impl ProtocolConfig {
                     cfg.feature_flags.max_ptb_value_size_v2 = true;
                     // Let system objects grow past the per-object size bound.
                     cfg.feature_flags.allow_unbounded_system_objects = true;
+                    // Enable the optimistic commit rule (StarfishSpeed) in
+                    // Starfish consensus.
+                    cfg.feature_flags.consensus_starfish_speed = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
@@ -42,6 +42,7 @@ feature_flags:
   consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
+  consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   pcool_skip_immutable_object_locks: true
   validator_metadata_verify_v2: true


### PR DESCRIPTION
# Description of change

Enable the optimistic commit rule (StarfishSpeed) in Starfish consensus on mainnet, in protocol version 35. Devnet (v31) and testnet (v32) already run it.

## Links to any relevant issues

fixes #12800

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable the optimistic commit rule (StarfishSpeed) in Starfish consensus on mainnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
