### PR TITLE
feat(graphql): drop DISTINCT ON and extend object cursor to support multi-version objectKeys

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.snap
@@ -152,7 +152,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -167,7 +167,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -182,7 +182,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -197,7 +197,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -219,7 +219,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -234,7 +234,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -249,7 +249,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -271,7 +271,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }
@@ -286,7 +286,7 @@ Response: {
                     "objects": {
                       "edges": [
                         {
-                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAA="
+                          "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qAwAAAAAAAAADAAAAAAAAAA=="
                         }
                       ]
                     }

--- a/crates/iota-graphql-e2e-tests/tests/consistency/coins.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/coins.move
@@ -135,7 +135,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_1_1},2)
+//# run-graphql --cursors bcs(@{obj_1_1},4,2)
 # There should be two coins, and the coin owners should be the same as the owner of the first coin in the previous query
 {
   availableRange {
@@ -163,7 +163,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_1_1},1)
+//# run-graphql --cursors bcs(@{obj_1_1},2,1)
 # Outside of available range
 {
   availableRange {
@@ -191,7 +191,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_1_1},0)
+//# run-graphql --cursors bcs(@{obj_1_1},2,0)
 # Outside of available range
 {
   availableRange {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/coins.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/coins.snap
@@ -1,6 +1,5 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 818
 ---
 processed 15 tasks
 
@@ -268,7 +267,7 @@ Response: {
 }
 
 task 12, lines 138-164:
-//# run-graphql --cursors bcs(@{obj_1_1},2)
+//# run-graphql --cursors bcs(@{obj_1_1},4,2)
 Response: {
   "data": {
     "availableRange": {
@@ -319,7 +318,7 @@ Response: {
 }
 
 task 13, lines 166-192:
-//# run-graphql --cursors bcs(@{obj_1_1},1)
+//# run-graphql --cursors bcs(@{obj_1_1},2,1)
 Response: {
   "data": {
     "availableRange": {
@@ -370,7 +369,7 @@ Response: {
 }
 
 task 14, lines 194-220:
-//# run-graphql --cursors bcs(@{obj_1_1},0)
+//# run-graphql --cursors bcs(@{obj_1_1},2,0)
 Response: {
   "data": {
     "availableRange": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_no_filter.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_no_filter.move
@@ -36,7 +36,7 @@ module P0::m {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_0_0},1)
+//# run-graphql --cursors bcs(@{obj_0_0},2,1)
 {
   objects(before: "@{cursor_0}", last: 50) {
     nodes {
@@ -46,7 +46,7 @@ module P0::m {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_0_0},2)
+//# run-graphql --cursors bcs(@{obj_0_0},3,2)
 {
   objects(before: "@{cursor_0}", last: 50) {
     nodes {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_no_filter.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_no_filter.snap
@@ -47,7 +47,7 @@ task 5, line 37:
 Checkpoint created: 2
 
 task 6, lines 39-47:
-//# run-graphql --cursors bcs(@{obj_0_0},1)
+//# run-graphql --cursors bcs(@{obj_0_0},2,1)
 Response: {
   "data": {
     "objects": {
@@ -134,7 +134,7 @@ Response: {
 }
 
 task 7, lines 49-57:
-//# run-graphql --cursors bcs(@{obj_0_0},2)
+//# run-graphql --cursors bcs(@{obj_0_0},3,2)
 Response: {
   "data": {
     "objects": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_wrapped.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_wrapped.move
@@ -60,7 +60,7 @@ module P0::m {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_0_0},2)
+//# run-graphql --cursors bcs(@{obj_0_0},3,2)
 {
   objects(filter: {objectIds: ["@{obj_2_0}"]}, before: "@{cursor_0}") {
     nodes {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_wrapped.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/consistent_view_wrapped.snap
@@ -101,7 +101,7 @@ task 10, line 61:
 Checkpoint created: 3
 
 task 11, lines 63-72:
-//# run-graphql --cursors bcs(@{obj_0_0},2)
+//# run-graphql --cursors bcs(@{obj_0_0},3,2)
 Response: {
   "data": {
     "objects": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.snap
@@ -131,7 +131,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0AQAAAAAAAAA=",
+            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0BAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA=="
@@ -142,7 +142,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuAAQAAAAAAAAA=",
+            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ=="
@@ -153,7 +153,7 @@ Response: {
             }
           },
           {
-            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0AAQAAAAAAAAA=",
+            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0ABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg=="
@@ -187,7 +187,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0AQAAAAAAAAA=",
+            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0BAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA=="
@@ -198,7 +198,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuAAQAAAAAAAAA=",
+            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ=="
@@ -209,7 +209,7 @@ Response: {
             }
           },
           {
-            "cursor": "IMLJhsnVZodSpYwJoiKfF3kNHye1ihAddPx0WGiGxKw2AQAAAAAAAAA=",
+            "cursor": "IMLJhsnVZodSpYwJoiKfF3kNHye1ihAddPx0WGiGxKw2AwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ=="
@@ -220,7 +220,7 @@ Response: {
             }
           },
           {
-            "cursor": "IMY+0QMC1n5JxcCwV89cZwPnGkowu1Fxz5MhIMs3n/sDAQAAAAAAAAA=",
+            "cursor": "IMY+0QMC1n5JxcCwV89cZwPnGkowu1Fxz5MhIMs3n/sDAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw=="
@@ -231,7 +231,7 @@ Response: {
             }
           },
           {
-            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0AAQAAAAAAAAA=",
+            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0ABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg=="
@@ -242,7 +242,7 @@ Response: {
             }
           },
           {
-            "cursor": "IPwFTVBmrzm0reXE4RCTAJ26VIXwFYgZ4H0stJw+2VOxAQAAAAAAAAA=",
+            "cursor": "IPwFTVBmrzm0reXE4RCTAJ26VIXwFYgZ4H0stJw+2VOxAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg=="
@@ -269,7 +269,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0AQAAAAAAAAA=",
+            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0BAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA=="
@@ -280,7 +280,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuAAQAAAAAAAAA=",
+            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ=="
@@ -291,7 +291,7 @@ Response: {
             }
           },
           {
-            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0AAQAAAAAAAAA=",
+            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0ABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg=="
@@ -325,7 +325,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0AQAAAAAAAAA=",
+            "cursor": "IBdJyFZgAd3FF4kUA2ChBc3/KHCheQ4d6azocaJ074V0BAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA=="
@@ -336,7 +336,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuAAQAAAAAAAAA=",
+            "cursor": "IHxoRI3Ce6B/guuh3eNs1qH336WmuI7nYdX85L26PEuABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ=="
@@ -347,7 +347,7 @@ Response: {
             }
           },
           {
-            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0AAQAAAAAAAAA=",
+            "cursor": "IMqQupB6O4axj4yBPPakqB9dSiVLWP/F7L4oaURajy0ABAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg=="

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.snap
@@ -83,7 +83,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "INQuQ3jyFzV95bwyIcRosrx+zzxFrc0vzVBfpgtDrfn2AQAAAAAAAAA=",
+            "cursor": "INQuQ3jyFzV95bwyIcRosrx+zzxFrc0vzVBfpgtDrfn2AwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -119,7 +119,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "INQuQ3jyFzV95bwyIcRosrx+zzxFrc0vzVBfpgtDrfn2AQAAAAAAAAA=",
+            "cursor": "INQuQ3jyFzV95bwyIcRosrx+zzxFrc0vzVBfpgtDrfn2AwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.snap
@@ -60,7 +60,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IMpvIL9ggW4aSwO6KfzZSHN5JlxYk5eaN0MF7y0VOZufAQAAAAAAAAA=",
+            "cursor": "IMpvIL9ggW4aSwO6KfzZSHN5JlxYk5eaN0MF7y0VOZufAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -96,7 +96,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IMpvIL9ggW4aSwO6KfzZSHN5JlxYk5eaN0MF7y0VOZufAQAAAAAAAAA=",
+            "cursor": "IMpvIL9ggW4aSwO6KfzZSHN5JlxYk5eaN0MF7y0VOZufAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -132,7 +132,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IMpvIL9ggW4aSwO6KfzZSHN5JlxYk5eaN0MF7y0VOZufAQAAAAAAAAA=",
+            "cursor": "IMpvIL9ggW4aSwO6KfzZSHN5JlxYk5eaN0MF7y0VOZufAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.snap
@@ -98,7 +98,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPAQAAAAAAAAA=",
+            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPBwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -134,7 +134,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPAQAAAAAAAAA=",
+            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPBwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -176,7 +176,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPAQAAAAAAAAA=",
+            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -219,7 +219,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPAQAAAAAAAAA=",
+            "cursor": "ILenYtUYIlLuh1nzefoJSEfFwoNunoE01VPp8R5K7aKPBwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.move
@@ -63,7 +63,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_3_0},1)
+//# run-graphql --cursors bcs(@{obj_3_0},3,1)
 {
   cv1_after: owner(address: "@{obj_2_2}") {
     dynamicFields(after: "@{cursor_0}") {
@@ -87,7 +87,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_0},2)
+//# run-graphql --cursors bcs(@{obj_3_0},3,2)
 {
   cv2_after: owner(address: "@{obj_2_2}") {
     dynamicFields(after: "@{cursor_0}") {
@@ -111,7 +111,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_0},3)
+//# run-graphql --cursors bcs(@{obj_3_0},3,3)
 {
   cv3_after: owner(address: "@{obj_2_2}") {
     dynamicFields(after: "@{cursor_0}") {
@@ -135,7 +135,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_0},4)
+//# run-graphql --cursors bcs(@{obj_3_0},3,4)
 {
   cv4_after: owner(address: "@{obj_2_2}") {
     dynamicFields(after: "@{cursor_0}") {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_recreate_across_checkpoints.snap
@@ -1,6 +1,5 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 818
 ---
 processed 15 tasks
 
@@ -93,7 +92,7 @@ task 10, line 64:
 Checkpoint created: 4
 
 task 11, lines 66-88:
-//# run-graphql --cursors bcs(@{obj_3_0},1)
+//# run-graphql --cursors bcs(@{obj_3_0},3,1)
 Response: {
   "data": {
     "cv1_after": {
@@ -110,7 +109,7 @@ Response: {
 }
 
 task 12, lines 90-112:
-//# run-graphql --cursors bcs(@{obj_3_0},2)
+//# run-graphql --cursors bcs(@{obj_3_0},3,2)
 Response: {
   "data": {
     "cv2_after": {
@@ -143,7 +142,7 @@ Response: {
 }
 
 task 13, lines 114-136:
-//# run-graphql --cursors bcs(@{obj_3_0},3)
+//# run-graphql --cursors bcs(@{obj_3_0},3,3)
 Response: {
   "data": {
     "cv3_after": {
@@ -160,7 +159,7 @@ Response: {
 }
 
 task 14, lines 138-160:
-//# run-graphql --cursors bcs(@{obj_3_0},4)
+//# run-graphql --cursors bcs(@{obj_3_0},3,4)
 Response: {
   "data": {
     "cv4_after": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
@@ -174,7 +174,7 @@ fragment DynamicFieldsSelect on DynamicFieldConnection {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_5_0},1) bcs(@{obj_5_0},2)
+//# run-graphql --cursors bcs(@{obj_5_0},3,1) bcs(@{obj_5_0},3,2)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs
@@ -285,7 +285,7 @@ fragment DynamicFieldSelect on DynamicField {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},3)
+//# run-graphql --cursors bcs(@{obj_5_0},3,2) bcs(@{obj_5_0},3,3)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs
@@ -346,7 +346,7 @@ fragment DynamicFieldsSelect on DynamicFieldConnection {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
+//# run-graphql --cursors bcs(@{obj_5_0},3,2) bcs(@{obj_5_0},3,4)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs
@@ -447,7 +447,7 @@ fragment DynamicFieldSelect on DynamicField {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
+//# run-graphql --cursors bcs(@{obj_5_0},3,2) bcs(@{obj_5_0},3,4)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.snap
@@ -1,6 +1,5 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 818
 ---
 processed 37 tasks
 
@@ -123,7 +122,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AQAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -190,14 +189,14 @@ task 13, line 175:
 Checkpoint created: 2
 
 task 14, lines 177-237:
-//# run-graphql --cursors bcs(@{obj_5_0},1) bcs(@{obj_5_0},2)
+//# run-graphql --cursors bcs(@{obj_5_0},3,1) bcs(@{obj_5_0},3,2)
 Response: {
   "data": {
     "parent_version_3_only_dof": {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AgAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -222,7 +221,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3AgAAAAAAAAA=",
+            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3BAAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw==",
@@ -236,7 +235,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74AgAAAAAAAAA=",
+            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74BAAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg==",
@@ -250,7 +249,7 @@ Response: {
             }
           },
           {
-            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlAgAAAAAAAAA=",
+            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlBAAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ==",
@@ -264,7 +263,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AgAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -405,14 +404,14 @@ task 19, line 286:
 Checkpoint created: 3
 
 task 20, lines 288-338:
-//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},3)
+//# run-graphql --cursors bcs(@{obj_5_0},3,2) bcs(@{obj_5_0},3,3)
 Response: {
   "data": {
     "parent_version_4_has_4_children": {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3AwAAAAAAAAA=",
+            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3BAAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw==",
@@ -426,7 +425,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74AwAAAAAAAAA=",
+            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74BAAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg==",
@@ -440,7 +439,7 @@ Response: {
             }
           },
           {
-            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlAwAAAAAAAAA=",
+            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlBAAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ==",
@@ -454,7 +453,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -484,7 +483,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBxoBlEqIeqmI9eBax5SEVGQRo+yTy+i55I36oG94avbAwAAAAAAAAA=",
+            "cursor": "IBxoBlEqIeqmI9eBax5SEVGQRo+yTy+i55I36oG94avbBQAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA==",
@@ -498,7 +497,7 @@ Response: {
             }
           },
           {
-            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3AwAAAAAAAAA=",
+            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3BAAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw==",
@@ -512,7 +511,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE1BzrRT50K3dCDInv5mJWqf/SVPi3/qS2aBHIz2ZVdfAwAAAAAAAAA=",
+            "cursor": "IE1BzrRT50K3dCDInv5mJWqf/SVPi3/qS2aBHIz2ZVdfBQAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ==",
@@ -526,7 +525,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE6/qBv5bWyoRdTXt5h7xiCoGQrWaZsQFVr8OYY2DeFdAwAAAAAAAAA=",
+            "cursor": "IE6/qBv5bWyoRdTXt5h7xiCoGQrWaZsQFVr8OYY2DeFdBQAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg==",
@@ -540,7 +539,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74AwAAAAAAAAA=",
+            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74BAAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg==",
@@ -554,7 +553,7 @@ Response: {
             }
           },
           {
-            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlAwAAAAAAAAA=",
+            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlBAAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ==",
@@ -568,7 +567,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -639,14 +638,14 @@ task 24, line 347:
 Checkpoint created: 4
 
 task 25, lines 349-399:
-//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
+//# run-graphql --cursors bcs(@{obj_5_0},3,2) bcs(@{obj_5_0},3,4)
 Response: {
   "data": {
     "parent_version_4_has_df1_2_3": {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3BAAAAAAAAAA=",
+            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3BAAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw==",
@@ -660,7 +659,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74BAAAAAAAAAA=",
+            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74BAAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg==",
@@ -674,7 +673,7 @@ Response: {
             }
           },
           {
-            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlBAAAAAAAAAA=",
+            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlBAAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ==",
@@ -688,7 +687,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7BAAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -718,7 +717,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBxoBlEqIeqmI9eBax5SEVGQRo+yTy+i55I36oG94avbBAAAAAAAAAA=",
+            "cursor": "IBxoBlEqIeqmI9eBax5SEVGQRo+yTy+i55I36oG94avbBQAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA==",
@@ -732,7 +731,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE1BzrRT50K3dCDInv5mJWqf/SVPi3/qS2aBHIz2ZVdfBAAAAAAAAAA=",
+            "cursor": "IE1BzrRT50K3dCDInv5mJWqf/SVPi3/qS2aBHIz2ZVdfBQAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ==",
@@ -746,7 +745,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE6/qBv5bWyoRdTXt5h7xiCoGQrWaZsQFVr8OYY2DeFdBAAAAAAAAAA=",
+            "cursor": "IE6/qBv5bWyoRdTXt5h7xiCoGQrWaZsQFVr8OYY2DeFdBQAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg==",
@@ -760,7 +759,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7BAAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -829,7 +828,7 @@ task 34, line 448:
 Checkpoint created: 8
 
 task 35, lines 450-508:
-//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
+//# run-graphql --cursors bcs(@{obj_5_0},3,2) bcs(@{obj_5_0},3,4)
 Response: {
   "data": {
     "availableRange": {
@@ -844,7 +843,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3CAAAAAAAAAA=",
+            "cursor": "IBzeTue1XsgMDY1gohd7II/ts2sOHWC7tan+wRzLJfZ3BAAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw==",
@@ -858,7 +857,7 @@ Response: {
             }
           },
           {
-            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74CAAAAAAAAAA=",
+            "cursor": "IHFX3O1yuKR/xMsPcBaHHwSN9iw6Ec3lhBUKIFf1S+74BAAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg==",
@@ -872,7 +871,7 @@ Response: {
             }
           },
           {
-            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlCAAAAAAAAAA=",
+            "cursor": "INzmC22cxVEPsRD/sADbb+3OgasMgkaiYy9DEiP5M2dlBAAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ==",
@@ -886,7 +885,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7CAAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",
@@ -916,7 +915,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IBxoBlEqIeqmI9eBax5SEVGQRo+yTy+i55I36oG94avbCAAAAAAAAAA=",
+            "cursor": "IBxoBlEqIeqmI9eBax5SEVGQRo+yTy+i55I36oG94avbBQAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNA==",
@@ -930,7 +929,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE1BzrRT50K3dCDInv5mJWqf/SVPi3/qS2aBHIz2ZVdfCAAAAAAAAAA=",
+            "cursor": "IE1BzrRT50K3dCDInv5mJWqf/SVPi3/qS2aBHIz2ZVdfBQAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNQ==",
@@ -944,7 +943,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE6/qBv5bWyoRdTXt5h7xiCoGQrWaZsQFVr8OYY2DeFdCAAAAAAAAAA=",
+            "cursor": "IE6/qBv5bWyoRdTXt5h7xiCoGQrWaZsQFVr8OYY2DeFdBQAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmNg==",
@@ -958,7 +957,7 @@ Response: {
             }
           },
           {
-            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7CAAAAAAAAAA=",
+            "cursor": "IO53M+MvTXpggmw3a4XxAozDxT5+PDBBgqapE3N1EXl7AwAAAAAAAAAIAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "pAEAAAAAAAA=",

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.snap
@@ -123,7 +123,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IAkupHMC/N2LXodj7vkddNcaCcsZwR25rA03IE7MlmJKAQAAAAAAAAA=",
+            "cursor": "IAkupHMC/N2LXodj7vkddNcaCcsZwR25rA03IE7MlmJKAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg=="
@@ -134,7 +134,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE9XGQh9caQ/MfIDapykcDRbZRXNgrKvsWy5UvLcewCSAQAAAAAAAAA=",
+            "cursor": "IE9XGQh9caQ/MfIDapykcDRbZRXNgrKvsWy5UvLcewCSAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ=="
@@ -145,7 +145,7 @@ Response: {
             }
           },
           {
-            "cursor": "IPD4tovAjlP4/5+z4HeAphVDVV0rv6RgVyugyRx6m7DjAQAAAAAAAAA=",
+            "cursor": "IPD4tovAjlP4/5+z4HeAphVDVV0rv6RgVyugyRx6m7DjAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw=="
@@ -263,7 +263,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IAkupHMC/N2LXodj7vkddNcaCcsZwR25rA03IE7MlmJKAgAAAAAAAAA=",
+            "cursor": "IAkupHMC/N2LXodj7vkddNcaCcsZwR25rA03IE7MlmJKAwAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMg=="
@@ -274,7 +274,7 @@ Response: {
             }
           },
           {
-            "cursor": "IE9XGQh9caQ/MfIDapykcDRbZRXNgrKvsWy5UvLcewCSAgAAAAAAAAA=",
+            "cursor": "IE9XGQh9caQ/MfIDapykcDRbZRXNgrKvsWy5UvLcewCSBQAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMQ=="
@@ -285,7 +285,7 @@ Response: {
             }
           },
           {
-            "cursor": "IPD4tovAjlP4/5+z4HeAphVDVV0rv6RgVyugyRx6m7DjAgAAAAAAAAA=",
+            "cursor": "IPD4tovAjlP4/5+z4HeAphVDVV0rv6RgVyugyRx6m7DjAwAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "A2RmMw=="

--- a/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.snap
@@ -83,7 +83,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiAQAAAAAAAAA=",
+            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -119,7 +119,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiAQAAAAAAAAA=",
+            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -239,7 +239,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiAwAAAAAAAAA=",
+            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiBwAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -275,7 +275,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiAwAAAAAAAAA=",
+            "cursor": "IOClWCd1aoZGVRPQUB+jciu8ZdhllqBXcY77izg/ifRiBwAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.snap
@@ -575,19 +575,19 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBgAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAGAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6BgAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAGAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iBgAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iBQAAAAAAAAAGAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKBgAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAGAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BgAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAGAAAAAAAAAA=="
                   }
                 ]
               }
@@ -606,28 +606,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }
@@ -642,28 +642,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }
@@ -678,28 +678,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }
@@ -714,28 +714,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }
@@ -750,28 +750,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }
@@ -786,28 +786,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }
@@ -822,28 +822,28 @@ Response: {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLDAAAAAAAAAA="
+                    "cursor": "IAwwiJU7vItNFQxp6oC+QF4W5zCTojMZta6S1duo5UTLBAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6DAAAAAAAAAA="
+                    "cursor": "IBzse/Pbi2ln6+T7vZ8jbZ+omUziDaImYMd55IfEGtx6AwAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iDAAAAAAAAAA="
+                    "cursor": "ICrSFfZ5PxfhcXzc3BjyzJw0vFoQnQ/2sfKEDfeYCu4iCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwDAAAAAAAAAA="
+                    "cursor": "IFHkjchOHE1RR0x+0Bh8xyhnX+agCV8/4F5E9r/4t1FwCAAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1DAAAAAAAAAA="
+                    "cursor": "IGZE81EFZhJ0/Ro7+PTDGPwgSNaaNyvk+cnvuHuzlX+1BgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKDAAAAAAAAAA="
+                    "cursor": "IH311tWqaod3yzQXFp0R0pxE4w9cYXtxOHwOYObwiqtKAgAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3DAAAAAAAAAA="
+                    "cursor": "IJS5ADCMS/D50qyMy17LiVXQ5dkWSfAL7MKyreIUcbC3BQAAAAAAAAAMAAAAAAAAAA=="
                   },
                   {
-                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocDAAAAAAAAAA="
+                    "cursor": "ILXFVQxVhtR2l1n+/9xJhgVLIXtZzNM+1VrOlfbNPoocBwAAAAAAAAAMAAAAAAAAAA=="
                   }
                 ]
               }

--- a/crates/iota-graphql-e2e-tests/tests/consistency/object_at_version.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/object_at_version.move
@@ -277,7 +277,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_1_0},6)
+//# run-graphql --cursors bcs(@{obj_1_0},1,6)
 {
   availableRange {
     first {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/object_at_version.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/object_at_version.snap
@@ -338,7 +338,7 @@ Response: {
 }
 
 task 32, lines 280-299:
-//# run-graphql --cursors bcs(@{obj_1_0},6)
+//# run-graphql --cursors bcs(@{obj_1_0},1,6)
 Response: {
   "data": {
     "availableRange": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination.move
@@ -34,7 +34,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_2_0},3,@{highest_checkpoint}) bcs(@{obj_3_0},4,@{highest_checkpoint})
 {
   one_of_these_will_yield_an_object: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -70,7 +70,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_2_0},1) bcs(@{obj_3_0},1)
+//# run-graphql --cursors bcs(@{obj_2_0},3,1) bcs(@{obj_3_0},4,1)
 {
   paginating_on_checkpoint_1: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -149,7 +149,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_6_0},2)
+//# run-graphql --cursors bcs(@{obj_6_0},5,2)
 {
   after_obj_6_0_at_checkpoint_2: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -229,7 +229,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_6_0},2)
+//# run-graphql --cursors bcs(@{obj_6_0},5,2)
 # This query will error due to requesting data outside of available range
 {
   availableRange {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination.snap
@@ -1,6 +1,5 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 818
 ---
 processed 26 tasks
 
@@ -45,7 +44,7 @@ task 4, line 35:
 Checkpoint created: 1
 
 task 5, lines 37-65:
-//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_2_0},3,@{highest_checkpoint}) bcs(@{obj_3_0},4,@{highest_checkpoint})
 Response: {
   "data": {
     "if_the_other_does_not": {
@@ -101,7 +100,7 @@ task 8, line 71:
 Checkpoint created: 2
 
 task 9, lines 73-101:
-//# run-graphql --cursors bcs(@{obj_2_0},1) bcs(@{obj_3_0},1)
+//# run-graphql --cursors bcs(@{obj_2_0},3,1) bcs(@{obj_3_0},4,1)
 Response: {
   "data": {
     "paginating_on_checkpoint_1": {
@@ -268,7 +267,7 @@ task 13, line 150:
 Checkpoint created: 3
 
 task 14, lines 152-214:
-//# run-graphql --cursors bcs(@{obj_6_0},2)
+//# run-graphql --cursors bcs(@{obj_6_0},5,2)
 Response: {
   "data": {
     "after_obj_6_0_at_checkpoint_2": {
@@ -549,7 +548,7 @@ task 22, line 230:
 Checkpoint created: 7
 
 task 23, lines 232-256:
-//# run-graphql --cursors bcs(@{obj_6_0},2)
+//# run-graphql --cursors bcs(@{obj_6_0},5,2)
 Response: {
   "data": {
     "availableRange": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
@@ -35,7 +35,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_3_0},4,@{highest_checkpoint})
 {
   after_obj_3_0: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -69,7 +69,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_3_0},1)
+//# run-graphql --cursors bcs(@{obj_3_0},4,1)
 # This query should yield the same results as the previous one.
 {
   after_obj_3_0_chkpt_1: address(address: "@{A}") {
@@ -100,7 +100,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_0},2)
+//# run-graphql --cursors bcs(@{obj_3_0},4,2)
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}) {
@@ -181,7 +181,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_3_0},2)
+//# run-graphql --cursors bcs(@{obj_3_0},4,2)
 # This query should yield the same results as the previous one.
 {
     after_obj_3_0_chkpt_2: address(address: "@{A}") {
@@ -246,7 +246,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_0},3)
+//# run-graphql --cursors bcs(@{obj_3_0},6,3)
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}) {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination_single.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/objects_pagination_single.snap
@@ -54,7 +54,7 @@ task 5, line 36:
 Checkpoint created: 1
 
 task 6, lines 38-66:
-//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_3_0},4,@{highest_checkpoint})
 Response: {
   "data": {
     "after_obj_3_0": {
@@ -98,7 +98,7 @@ task 8, line 70:
 Checkpoint created: 2
 
 task 9, lines 72-101:
-//# run-graphql --cursors bcs(@{obj_3_0},1)
+//# run-graphql --cursors bcs(@{obj_3_0},4,1)
 Response: {
   "data": {
     "after_obj_3_0_chkpt_1": {
@@ -128,7 +128,7 @@ Response: {
 }
 
 task 10, lines 103-178:
-//# run-graphql --cursors bcs(@{obj_3_0},2)
+//# run-graphql --cursors bcs(@{obj_3_0},4,2)
 Response: {
   "data": {
     "address": {
@@ -234,7 +234,7 @@ task 12, line 182:
 Checkpoint created: 3
 
 task 13, lines 184-247:
-//# run-graphql --cursors bcs(@{obj_3_0},2)
+//# run-graphql --cursors bcs(@{obj_3_0},4,2)
 Response: {
   "data": {
     "after_obj_3_0_chkpt_2": {
@@ -296,7 +296,7 @@ Response: {
 }
 
 task 14, lines 249-324:
-//# run-graphql --cursors bcs(@{obj_3_0},3)
+//# run-graphql --cursors bcs(@{obj_3_0},6,3)
 Response: {
   "data": {
     "address": {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.move
@@ -56,7 +56,7 @@
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_1},1) bcs(@{obj_7_0},1)
+//# run-graphql --cursors bcs(@{obj_3_1},3,1) bcs(@{obj_7_0},5,1)
 # Even though there is a stake created after the initial one, the cursor locks the upper bound to
 # checkpoint 1 - at that point in time, we did not have any additional stakes.
 {
@@ -102,7 +102,7 @@
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_1},3) bcs(@{obj_7_0},3)
+//# run-graphql --cursors bcs(@{obj_3_1},3,3) bcs(@{obj_7_0},5,3)
 # The second stake was created at checkpoint 3, and thus will be visible.
 {
   coins_after_obj_3_1_chkpt_3: address(address: "@{C}") {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.snap
@@ -132,13 +132,13 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FBAAAAAAAAAA=",
+            "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAwAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "principal": "10000000000"
             }
           },
           {
-            "cursor": "IN5VIiEFPvVw12ITluU5QzdVnNTf341NVGgloWAYJX7VBAAAAAAAAAA=",
+            "cursor": "IN5VIiEFPvVw12ITluU5QzdVnNTf341NVGgloWAYJX7VBQAAAAAAAAAEAAAAAAAAAA==",
             "node": {
               "principal": "10000000000"
             }
@@ -150,7 +150,7 @@ Response: {
 }
 
 task 13, lines 59-103:
-//# run-graphql --cursors bcs(@{obj_3_1},1) bcs(@{obj_7_0},1)
+//# run-graphql --cursors bcs(@{obj_3_1},3,1) bcs(@{obj_7_0},5,1)
 Response: {
   "data": {
     "no_coins_after_obj_3_0_chkpt_1": {
@@ -177,7 +177,7 @@ Response: {
 }
 
 task 14, lines 105-148:
-//# run-graphql --cursors bcs(@{obj_3_1},3) bcs(@{obj_7_0},3)
+//# run-graphql --cursors bcs(@{obj_3_1},3,3) bcs(@{obj_7_0},5,3)
 Response: {
   "data": {
     "coins_after_obj_3_1_chkpt_3": {
@@ -189,7 +189,7 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IN5VIiEFPvVw12ITluU5QzdVnNTf341NVGgloWAYJX7VAwAAAAAAAAA=",
+            "cursor": "IN5VIiEFPvVw12ITluU5QzdVnNTf341NVGgloWAYJX7VBQAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "principal": "10000000000"
             }
@@ -201,7 +201,7 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAwAAAAAAAAA=",
+            "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAwAAAAAAAAADAAAAAAAAAA==",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/iota-graphql-e2e-tests/tests/objects/coin.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/coin.snap
@@ -54,7 +54,7 @@ Response: {
       "coins": {
         "edges": [
           {
-            "cursor": "INNUgLY/0naiwb5be28kr+hOzRhK6O/eRpeRYJaPdg7rAQAAAAAAAAA=",
+            "cursor": "INNUgLY/0naiwb5be28kr+hOzRhK6O/eRpeRYJaPdg7rAgAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "coinBalance": "299999983382000",
               "contents": {
@@ -84,7 +84,7 @@ Response: {
     "fakeCoins": {
       "edges": [
         {
-          "cursor": "IGTQkzLYvf6IeIFSqxnStvUjx+SpGkWIVh0SJasNdEFgAQAAAAAAAAA=",
+          "cursor": "IGTQkzLYvf6IeIFSqxnStvUjx+SpGkWIVh0SJasNdEFgAgAAAAAAAAABAAAAAAAAAA==",
           "node": {
             "coinBalance": "1",
             "contents": {
@@ -95,7 +95,7 @@ Response: {
           }
         },
         {
-          "cursor": "IJCciOCIiKOVgRANnkv2Ek+63tGQRaRvBTdoC5n6uBeKAQAAAAAAAAA=",
+          "cursor": "IJCciOCIiKOVgRANnkv2Ek+63tGQRaRvBTdoC5n6uBeKAgAAAAAAAAABAAAAAAAAAA==",
           "node": {
             "coinBalance": "3",
             "contents": {
@@ -106,7 +106,7 @@ Response: {
           }
         },
         {
-          "cursor": "IMgdXp2TGN2R8SESmdKnbHB97gHQlsVG1EhT1QBdKAjgAQAAAAAAAAA=",
+          "cursor": "IMgdXp2TGN2R8SESmdKnbHB97gHQlsVG1EhT1QBdKAjgAgAAAAAAAAABAAAAAAAAAA==",
           "node": {
             "coinBalance": "2",
             "contents": {
@@ -121,7 +121,7 @@ Response: {
     "iotaCoins": {
       "edges": [
         {
-          "cursor": "IHQYRhDrG+U4Mtk7XANbay/D7RiOuc6/tqZtP2CrXkzWAQAAAAAAAAA=",
+          "cursor": "IHQYRhDrG+U4Mtk7XANbay/D7RiOuc6/tqZtP2CrXkzWAQAAAAAAAAABAAAAAAAAAA==",
           "node": {
             "coinBalance": "300000000000000",
             "contents": {
@@ -132,7 +132,7 @@ Response: {
           }
         },
         {
-          "cursor": "INNUgLY/0naiwb5be28kr+hOzRhK6O/eRpeRYJaPdg7rAQAAAAAAAAA=",
+          "cursor": "INNUgLY/0naiwb5be28kr+hOzRhK6O/eRpeRYJaPdg7rAgAAAAAAAAABAAAAAAAAAA==",
           "node": {
             "coinBalance": "299999983382000",
             "contents": {
@@ -143,7 +143,7 @@ Response: {
           }
         },
         {
-          "cursor": "IN1dw8JSMZ3fTkObz72dmGJuhvfZkEEkgWwbSuqY+X4/AQAAAAAAAAA=",
+          "cursor": "IN1dw8JSMZ3fTkObz72dmGJuhvfZkEEkgWwbSuqY+X4/AQAAAAAAAAABAAAAAAAAAA==",
           "node": {
             "coinBalance": "30000000000000000",
             "contents": {

--- a/crates/iota-graphql-e2e-tests/tests/objects/object_keys_multiple_versions.move
+++ b/crates/iota-graphql-e2e-tests/tests/objects/object_keys_multiple_versions.move
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests that an objectKeys filter can pin multiple versions of the same
+// object at once, and that cursor pagination works across rows that share an
+// object_id and differ only in version.
+
+//# init --protocol-version 4 --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun update(value: u64, o: &mut Object) {
+        o.value = value;
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# run Test::M1::update --sender A --args 100 object(2,0)
+
+//# run Test::M1::update --sender A --args 200 object(2,0)
+
+//# create-checkpoint
+
+//# run Test::M1::update --sender A --args 300 object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql
+# All four versions of the same object are returned: three from
+# objects_backward_history and the current one from checkpointed_objects.
+{
+  objects(
+    filter: {
+      objectKeys: [
+        {objectId: "@{obj_2_0}", version: 3},
+        {objectId: "@{obj_2_0}", version: 4},
+        {objectId: "@{obj_2_0}", version: 5},
+        {objectId: "@{obj_2_0}", version: 6}
+      ]
+    }
+  ) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Page boundary falls inside the same-id cluster: the first page ends between
+# version 4 and version 5.
+{
+  objects(
+    first: 2
+    filter: {
+      objectKeys: [
+        {objectId: "@{obj_2_0}", version: 3},
+        {objectId: "@{obj_2_0}", version: 4},
+        {objectId: "@{obj_2_0}", version: 5},
+        {objectId: "@{obj_2_0}", version: 6}
+      ]
+    }
+  ) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    nodes {
+      version
+    }
+  }
+}
+
+//# run-graphql --cursors bcs(@{obj_2_0},4,2)
+# Resuming from a cursor pointing at version 4 returns the remaining
+# versions 5 and 6.
+{
+  objects(
+    after: "@{cursor_0}"
+    filter: {
+      objectKeys: [
+        {objectId: "@{obj_2_0}", version: 3},
+        {objectId: "@{obj_2_0}", version: 4},
+        {objectId: "@{obj_2_0}", version: 5},
+        {objectId: "@{obj_2_0}", version: 6}
+      ]
+    }
+  ) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    nodes {
+      version
+    }
+  }
+}
+
+//# run-graphql --cursors bcs(@{obj_2_0},5,2)
+# Paginating backwards from a cursor pointing at version 5 returns
+# versions 3 and 4.
+{
+  objects(
+    last: 2
+    before: "@{cursor_0}"
+    filter: {
+      objectKeys: [
+        {objectId: "@{obj_2_0}", version: 3},
+        {objectId: "@{obj_2_0}", version: 4},
+        {objectId: "@{obj_2_0}", version: 5},
+        {objectId: "@{obj_2_0}", version: 6}
+      ]
+    }
+  ) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    nodes {
+      version
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/objects/object_keys_multiple_versions.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/object_keys_multiple_versions.snap
@@ -1,0 +1,189 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 10-27:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 5449200
+├── Storage Rebate: 0
+└── Non-Refundable Storage Fee: 0
+
+task 2, line 29:
+//# run Test::M1::create --args 0 @A
+created: object(2,0)
+mutated: object(0,1)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2287600
+├── Storage Rebate: 980400
+└── Non-Refundable Storage Fee: 0
+
+task 3, line 31:
+//# run Test::M1::update --sender A --args 100 object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2287600
+├── Storage Rebate: 1307200
+└── Non-Refundable Storage Fee: 0
+
+task 4, line 33:
+//# run Test::M1::update --sender A --args 200 object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2287600
+├── Storage Rebate: 2287600
+└── Non-Refundable Storage Fee: 0
+
+task 5, line 35:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, line 37:
+//# run Test::M1::update --sender A --args 300 object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary:
+├── Computation Cost: 1000000
+├── Computation Cost Burned: 1000000
+├── Storage Cost: 2287600
+├── Storage Rebate: 2287600
+└── Non-Refundable Storage Fee: 0
+
+task 7, line 39:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 41-68:
+//# run-graphql
+Response: {
+  "data": {
+    "objects": {
+      "nodes": [
+        {
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "id": "0x454c6b9eefdb29dd16774dfbc839408886d3dec16bf1f55997c758326847645c",
+                "value": "0"
+              }
+            }
+          },
+          "version": 3
+        },
+        {
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "id": "0x454c6b9eefdb29dd16774dfbc839408886d3dec16bf1f55997c758326847645c",
+                "value": "100"
+              }
+            }
+          },
+          "version": 4
+        },
+        {
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "id": "0x454c6b9eefdb29dd16774dfbc839408886d3dec16bf1f55997c758326847645c",
+                "value": "200"
+              }
+            }
+          },
+          "version": 5
+        },
+        {
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "id": "0x454c6b9eefdb29dd16774dfbc839408886d3dec16bf1f55997c758326847645c",
+                "value": "300"
+              }
+            }
+          },
+          "version": 6
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 9, lines 70-93:
+//# run-graphql
+Response: {
+  "data": {
+    "objects": {
+      "nodes": [
+        {
+          "version": 3
+        },
+        {
+          "version": 4
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}
+
+task 10, lines 95-118:
+//# run-graphql --cursors bcs(@{obj_2_0},4,2)
+Response: {
+  "data": {
+    "objects": {
+      "nodes": [
+        {
+          "version": 5
+        },
+        {
+          "version": 6
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true
+      }
+    }
+  }
+}
+
+task 11, lines 120-144:
+//# run-graphql --cursors bcs(@{obj_2_0},5,2)
+Response: {
+  "data": {
+    "objects": {
+      "nodes": [
+        {
+          "version": 3
+        },
+        {
+          "version": 4
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false
+      }
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/iota-graphql-e2e-tests/tests/objects/pagination.move
@@ -91,7 +91,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_5_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_5_0},6,@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select the 5th and 3rd objects
@@ -105,7 +105,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_4_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_4_0},5,@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select 1st object
@@ -117,7 +117,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_3_0},4,@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select no object

--- a/crates/iota-graphql-e2e-tests/tests/objects/pagination.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/pagination.snap
@@ -81,19 +81,19 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IB/UEvhb5e0rP0ewRxAbf5Qp8FtMN5onjFBAoToYJh+EAQAAAAAAAAA="
+            "cursor": "IB/UEvhb5e0rP0ewRxAbf5Qp8FtMN5onjFBAoToYJh+EBwAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "ICZ82g9/mWryqQRCxYfPYpDMFQpC7fy/PnKGdXFysszHAQAAAAAAAAA="
+            "cursor": "ICZ82g9/mWryqQRCxYfPYpDMFQpC7fy/PnKGdXFysszHBgAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXAQAAAAAAAAA="
+            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXBQAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAQAAAAAAAAA="
+            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAwAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "IL/cf/9GNFJN/BGC36aBlmNtdJ3tEPOPNlduX4LIAvi0AQAAAAAAAAA="
+            "cursor": "IL/cf/9GNFJN/BGC36aBlmNtdJ3tEPOPNlduX4LIAvi0BAAAAAAAAAABAAAAAAAAAA=="
           }
         ]
       }
@@ -109,10 +109,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IB/UEvhb5e0rP0ewRxAbf5Qp8FtMN5onjFBAoToYJh+EAQAAAAAAAAA="
+            "cursor": "IB/UEvhb5e0rP0ewRxAbf5Qp8FtMN5onjFBAoToYJh+EBwAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "ICZ82g9/mWryqQRCxYfPYpDMFQpC7fy/PnKGdXFysszHAQAAAAAAAAA="
+            "cursor": "ICZ82g9/mWryqQRCxYfPYpDMFQpC7fy/PnKGdXFysszHBgAAAAAAAAABAAAAAAAAAA=="
           }
         ]
       }
@@ -128,31 +128,31 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IB/UEvhb5e0rP0ewRxAbf5Qp8FtMN5onjFBAoToYJh+EAQAAAAAAAAA=",
+            "cursor": "IB/UEvhb5e0rP0ewRxAbf5Qp8FtMN5onjFBAoToYJh+EBwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0x1fd412f85be5ed2b3f47b047101b7f9429f05b4c379a278c5040a13a18261f84"
             }
           },
           {
-            "cursor": "ICZ82g9/mWryqQRCxYfPYpDMFQpC7fy/PnKGdXFysszHAQAAAAAAAAA=",
+            "cursor": "ICZ82g9/mWryqQRCxYfPYpDMFQpC7fy/PnKGdXFysszHBgAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0x267cda0f7f996af2a90442c587cf6290cc150a42edfcbf3e7286757172b2ccc7"
             }
           },
           {
-            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXAQAAAAAAAAA=",
+            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXBQAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0x7bb4eff769da118266d208087d125acdfc7d09d8cdcba1d409a6d7f7522ddc17"
             }
           },
           {
-            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAQAAAAAAAAA=",
+            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0x8782cfa9fc99b2c6e879ee5a17eaa4e2d40e105317773cd3d0f222ba8b835d0a"
             }
           },
           {
-            "cursor": "IL/cf/9GNFJN/BGC36aBlmNtdJ3tEPOPNlduX4LIAvi0AQAAAAAAAAA=",
+            "cursor": "IL/cf/9GNFJN/BGC36aBlmNtdJ3tEPOPNlduX4LIAvi0BAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0xbfdc7fff4634524dfc1182dfa68196636d749ded10f38f36576e5f82c802f8b4"
             }
@@ -179,17 +179,17 @@ Response: {
 }
 
 task 11, lines 94-106:
-//# run-graphql --cursors bcs(@{obj_5_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_5_0},6,@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
       "objects": {
         "edges": [
           {
-            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXAQAAAAAAAAA="
+            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXBQAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAQAAAAAAAAA="
+            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAwAAAAAAAAABAAAAAAAAAA=="
           }
         ]
       }
@@ -198,14 +198,14 @@ Response: {
 }
 
 task 12, lines 108-118:
-//# run-graphql --cursors bcs(@{obj_4_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_4_0},5,@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
       "objects": {
         "edges": [
           {
-            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAQAAAAAAAAA="
+            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAwAAAAAAAAABAAAAAAAAAA=="
           }
         ]
       }
@@ -214,17 +214,17 @@ Response: {
 }
 
 task 13, lines 120-130:
-//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
+//# run-graphql --cursors bcs(@{obj_3_0},4,@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
       "objects": {
         "edges": [
           {
-            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXAQAAAAAAAAA="
+            "cursor": "IHu07/dp2hGCZtIICH0SWs38fQnYzcuh1Amm1/dSLdwXBQAAAAAAAAABAAAAAAAAAA=="
           },
           {
-            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAQAAAAAAAAA="
+            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAwAAAAAAAAABAAAAAAAAAA=="
           }
         ]
       }
@@ -240,13 +240,13 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAQAAAAAAAAA=",
+            "cursor": "IIeCz6n8mbLG6HnuWhfqpOLUDhBTF3c809DyIrqLg10KAwAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0x8782cfa9fc99b2c6e879ee5a17eaa4e2d40e105317773cd3d0f222ba8b835d0a"
             }
           },
           {
-            "cursor": "IL/cf/9GNFJN/BGC36aBlmNtdJ3tEPOPNlduX4LIAvi0AQAAAAAAAAA=",
+            "cursor": "IL/cf/9GNFJN/BGC36aBlmNtdJ3tEPOPNlduX4LIAvi0BAAAAAAAAAABAAAAAAAAAA==",
             "node": {
               "address": "0xbfdc7fff4634524dfc1182dfa68196636d749ded10f38f36576e5f82c802f8b4"
             }

--- a/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.snap
+++ b/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.snap
@@ -18,7 +18,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "ILzVVmYs0lhGb4pvK+xM5LKrk6HwRKnJJTdjjehbb0VZAAAAAAAAAAA=",
+          "cursor": "ILzVVmYs0lhGb4pvK+xM5LKrk6HwRKnJJTdjjehbb0VZAQAAAAAAAAAAAAAAAAAAAA==",
           "node": {
             "asMoveObject": {
               "asStakedIota": {
@@ -74,7 +74,7 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAgAAAAAAAAA=",
+            "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAwAAAAAAAAACAAAAAAAAAA==",
             "node": {
               "principal": "10000000000"
             }
@@ -85,7 +85,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAgAAAAAAAAA=",
+          "cursor": "IBHJBM8kZPT8qybYKMvt0PxPYwH1wTbiHnqBSvB2UO3FAwAAAAAAAAACAAAAAAAAAA==",
           "node": {
             "asMoveObject": {
               "asStakedIota": {
@@ -96,7 +96,7 @@ Response: {
           }
         },
         {
-          "cursor": "ILzVVmYs0lhGb4pvK+xM5LKrk6HwRKnJJTdjjehbb0VZAgAAAAAAAAA=",
+          "cursor": "ILzVVmYs0lhGb4pvK+xM5LKrk6HwRKnJJTdjjehbb0VZAQAAAAAAAAACAAAAAAAAAA==",
           "node": {
             "asMoveObject": {
               "asStakedIota": {
@@ -107,7 +107,7 @@ Response: {
           }
         },
         {
-          "cursor": "IMU9f9gnuZx239pp/ScI5OWZ8fITK6HyPT8/lM94+yiyAgAAAAAAAAA=",
+          "cursor": "IMU9f9gnuZx239pp/ScI5OWZ8fITK6HyPT8/lM94+yiyBAAAAAAAAAACAAAAAAAAAA==",
           "node": {
             "asMoveObject": {
               "asStakedIota": {

--- a/crates/iota-graphql-rpc/src/backward_view/consistent.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/consistent.rs
@@ -6,7 +6,7 @@
 //! versions from `objects_backward_history`.
 
 use crate::{
-    backward_view::{ACTIVE, OBJECT_COLUMNS, merge_and_deduplicate},
+    backward_view::{ACTIVE, OBJECT_COLUMNS, merge},
     filter, query,
     raw_query::RawQuery,
     types::{
@@ -24,7 +24,7 @@ pub(crate) fn query(
     filter_fn: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     let checkpoint_viewed_at = checkpoint_viewed_at as i64;
-    merge_and_deduplicate(vec![
+    merge(vec![
         consistent_checkpointed_objects(checkpoint_viewed_at, page, &filter_fn),
         consistent_historical_objects(checkpoint_viewed_at, page, &filter_fn),
     ])

--- a/crates/iota-graphql-rpc/src/backward_view/dynamic_fields.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/dynamic_fields.rs
@@ -19,7 +19,7 @@
 use iota_indexer::types::OwnerType;
 
 use crate::{
-    backward_view::{OBJECT_COLUMNS, merge_and_deduplicate},
+    backward_view::{OBJECT_COLUMNS, merge},
     filter, query,
     raw_query::RawQuery,
     types::{
@@ -39,7 +39,7 @@ use crate::{
 pub(crate) fn query(parent: IotaAddress, parent_version: u64, page: &Page<Cursor>) -> RawQuery {
     let parent_version = parent_version as i64;
     let parent_filter = parent_dynamic_field_filter(parent);
-    merge_and_deduplicate(vec![
+    merge(vec![
         dynamic_fields_from_checkpointed_objects(parent_version, page, &parent_filter),
         dynamic_fields_from_historical_objects(parent_version, page, &parent_filter),
     ])
@@ -79,12 +79,6 @@ fn parent_dynamic_field_filter(parent: IotaAddress) -> impl Fn(RawQuery) -> RawQ
 /// the row level. This is needed because a `(id, version)` pair can
 /// briefly exist in both tables during the race window between
 /// `objects_backward_history` and `checkpointed_objects` writes.
-///
-/// # Implementation notes
-///
-/// The merge step uses `DISTINCT ON` to deduplicate *within a page* only;
-/// source-level disjointness is required to keep the result correct across
-/// page boundaries.
 fn dynamic_fields_from_checkpointed_objects(
     parent_version: i64,
     page: &Page<Cursor>,

--- a/crates/iota-graphql-rpc/src/backward_view/historical.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/historical.rs
@@ -7,7 +7,7 @@
 //! tombstones are excluded, so such versions resolve as non-existent.
 
 use crate::{
-    backward_view::{ACTIVE, HistoricalFilter, OBJECT_COLUMNS, merge_and_deduplicate},
+    backward_view::{ACTIVE, HistoricalFilter, OBJECT_COLUMNS, merge},
     filter, query,
     raw_query::RawQuery,
     types::{
@@ -22,7 +22,7 @@ use crate::{
 pub(crate) fn query(page: &Page<Cursor>, filter: &HistoricalFilter) -> RawQuery {
     let filter_fn = |q| filter.apply(q);
 
-    merge_and_deduplicate(vec![
+    merge(vec![
         checkpointed_objects(page, &filter_fn),
         historical_objects(page, &filter_fn),
     ])
@@ -30,6 +30,10 @@ pub(crate) fn query(page: &Page<Cursor>, filter: &HistoricalFilter) -> RawQuery 
 
 /// Returns active objects from `checkpointed_objects` that satisfy the
 /// provided filter.
+///
+/// Excludes rows that also appear in `objects_backward_history` at the same
+/// `(object_id, object_version)`. This is needed because a `(id, version)` pair
+/// can briefly exist in both tables during ingestion.
 fn checkpointed_objects(
     page: &Page<Cursor>,
     filter_fn: &impl Fn(RawQuery) -> RawQuery,
@@ -40,10 +44,14 @@ fn checkpointed_objects(
         ))),
         format!("object_status = {ACTIVE}")
     );
-    let source = query!(
-        "SELECT candidates.* FROM ({}) candidates",
-        checkpointed_filtered
+    let no_overlap = filter!(
+        checkpointed_filtered,
+        "NOT EXISTS (\
+             SELECT 1 FROM objects_backward_history bh \
+             WHERE bh.object_id = checkpointed_objects.object_id \
+               AND bh.object_version = checkpointed_objects.object_version)"
     );
+    let source = query!("SELECT candidates.* FROM ({}) candidates", no_overlap);
     page.apply::<StoredBackwardObject>(source)
 }
 

--- a/crates/iota-graphql-rpc/src/backward_view/mod.rs
+++ b/crates/iota-graphql-rpc/src/backward_view/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod historical;
 
 use iota_indexer::types::ObjectStatus as NativeObjectStatus;
 
-use crate::{query, raw_query::RawQuery, types::object::ObjectFilter};
+use crate::{raw_query::RawQuery, types::object::ObjectFilter};
 
 /// An `ObjectFilter` validated for use against the historical view.
 ///
@@ -65,16 +65,14 @@ pub(super) const OBJECT_COLUMNS: &str = "\
     object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, \
     object_type_name, serialized_object, coin_type, coin_balance, df_kind";
 
-/// Merges any non-empty set of sources with `UNION ALL` and picks the most
-/// recent version per `object_id` using `DISTINCT ON`.
+/// Merges any non-empty set of sources with `UNION ALL`.
 ///
-/// The result is wrapped so cursor pagination can reference
-/// `candidates.object_id`.
-pub(super) fn merge_and_deduplicate(sources: Vec<RawQuery>) -> RawQuery {
-    assert!(
-        !sources.is_empty(),
-        "merge_and_deduplicate requires at least one source"
-    );
+/// The merge does not deduplicate, so sources must be disjoint on
+/// `(object_id, object_version)` by construction. The result is wrapped so
+/// cursor pagination can reference `candidates.object_id` and
+/// `candidates.object_version`.
+pub(super) fn merge(sources: Vec<RawQuery>) -> RawQuery {
+    assert!(!sources.is_empty(), "merge requires at least one source");
 
     let mut binds: Vec<String> = Vec::new();
     let union_terms: Vec<String> = sources
@@ -86,14 +84,11 @@ pub(super) fn merge_and_deduplicate(sources: Vec<RawQuery>) -> RawQuery {
         })
         .collect();
 
-    let select = format!(
-        r#"SELECT DISTINCT ON (object_id) * FROM ({}) candidates"#,
-        union_terms.join(" UNION ALL ")
-    );
-
-    let combined = RawQuery::new(select, binds)
-        .order_by("object_id")
-        .order_by("object_version DESC");
-
-    query!("SELECT * FROM ({}) candidates", combined)
+    RawQuery::new(
+        format!(
+            "SELECT * FROM ({}) candidates",
+            union_terms.join(" UNION ALL ")
+        ),
+        binds,
+    )
 }

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -229,13 +229,17 @@ pub(crate) enum ObjectLookup {
 
 pub(crate) type Cursor = cursor::BcsCursor<HistoricalObjectCursor>;
 
-/// The inner struct for the `Object`'s cursor. The `object_id` is used as the
-/// cursor, while the `checkpoint_viewed_at` sets the consistent upper bound for
-/// the cursor.
+/// The inner struct for the `Object`'s cursor. The `(object_id,
+/// object_version)` pair is used as the cursor, to be able to paginate requests
+/// for multiple versions of the same object, while the `checkpoint_viewed_at`
+/// sets the consistent upper bound for the cursor.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub(crate) struct HistoricalObjectCursor {
     #[serde(rename = "o")]
     object_id: Vec<u8>,
+    /// The version of the object this cursor points at.
+    #[serde(rename = "v")]
+    object_version: u64,
     /// The checkpoint sequence number this was viewed at.
     #[serde(rename = "c")]
     checkpoint_viewed_at: u64,
@@ -823,10 +827,10 @@ impl Object {
     }
 
     /// Query the database for a `page` of some sub-type of Object. The page
-    /// uses the bytes of an Object ID and the checkpoint when the query was
-    /// made as the cursor, and can optionally be further `filter`-ed. The
-    /// subtype is created using the `downcast` function, which is allowed
-    /// to fail, if the downcast has failed.
+    /// uses the bytes of an Object ID, the object version and the checkpoint
+    /// when the query was made as the cursor, and can optionally be further
+    /// `filter`-ed. The subtype is created using the `downcast` function,
+    /// which is allowed to fail, if the downcast has failed.
     ///
     /// `checkpoint_viewed_at` represents the checkpoint sequence number at
     /// which this page was queried for. Each entity returned in the
@@ -1252,9 +1256,10 @@ impl ObjectFilter {
 }
 
 impl HistoricalObjectCursor {
-    pub(crate) fn new(object_id: Vec<u8>, checkpoint_viewed_at: u64) -> Self {
+    pub(crate) fn new(object_id: Vec<u8>, object_version: u64, checkpoint_viewed_at: u64) -> Self {
         Self {
             object_id,
+            object_version,
             checkpoint_viewed_at,
         }
     }
@@ -1267,45 +1272,6 @@ impl Checkpointed for Cursor {
 }
 
 impl ScanLimited for Cursor {}
-
-impl RawPaginated<Cursor> for StoredHistoryObject {
-    fn filter_ge(cursor: &Cursor, query: RawQuery) -> RawQuery {
-        filter!(
-            query,
-            format!(
-                "candidates.object_id >= '\\x{}'::bytea",
-                hex::encode(cursor.object_id.clone())
-            )
-        )
-    }
-
-    fn filter_le(cursor: &Cursor, query: RawQuery) -> RawQuery {
-        filter!(
-            query,
-            format!(
-                "candidates.object_id <= '\\x{}'::bytea",
-                hex::encode(cursor.object_id.clone())
-            )
-        )
-    }
-
-    fn order(asc: bool, query: RawQuery) -> RawQuery {
-        if asc {
-            query.order_by("candidates.object_id ASC")
-        } else {
-            query.order_by("candidates.object_id DESC")
-        }
-    }
-}
-
-impl Target<Cursor> for StoredHistoryObject {
-    fn cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
-        Cursor::new(HistoricalObjectCursor::new(
-            self.object_id.clone(),
-            checkpoint_viewed_at,
-        ))
-    }
-}
 
 /// Query-result struct for the backward diff read path. Used by
 /// `build_backward_objects_query` which unions `checkpointed_objects` and
@@ -1370,31 +1336,43 @@ impl StoredBackwardObject {
 }
 
 impl RawPaginated<Cursor> for StoredBackwardObject {
+    // Returns rows lexicographically greater or equal to (object_id,
+    // object_version). The AND/OR form is used instead of ROW(object_id,
+    // object_version) because the latter was producing slower plans when combined
+    // with other filters.
     fn filter_ge(cursor: &Cursor, query: RawQuery) -> RawQuery {
+        let id = hex::encode(cursor.object_id.clone());
         filter!(
             query,
             format!(
-                "candidates.object_id >= '\\x{}'::bytea",
-                hex::encode(cursor.object_id.clone())
+                "candidates.object_id >= '\\x{id}'::bytea AND \
+                 (candidates.object_id > '\\x{id}'::bytea OR candidates.object_version >= {})",
+                cursor.object_version
             )
         )
     }
 
     fn filter_le(cursor: &Cursor, query: RawQuery) -> RawQuery {
+        let id = hex::encode(cursor.object_id.clone());
         filter!(
             query,
             format!(
-                "candidates.object_id <= '\\x{}'::bytea",
-                hex::encode(cursor.object_id.clone())
+                "candidates.object_id <= '\\x{id}'::bytea AND \
+                 (candidates.object_id < '\\x{id}'::bytea OR candidates.object_version <= {})",
+                cursor.object_version
             )
         )
     }
 
     fn order(asc: bool, query: RawQuery) -> RawQuery {
         if asc {
-            query.order_by("candidates.object_id ASC")
+            query
+                .order_by("candidates.object_id ASC")
+                .order_by("candidates.object_version ASC")
         } else {
-            query.order_by("candidates.object_id DESC")
+            query
+                .order_by("candidates.object_id DESC")
+                .order_by("candidates.object_version DESC")
         }
     }
 }
@@ -1403,6 +1381,7 @@ impl Target<Cursor> for StoredBackwardObject {
     fn cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
         Cursor::new(HistoricalObjectCursor::new(
             self.object_id.clone(),
+            self.object_version as u64,
             checkpoint_viewed_at,
         ))
     }
@@ -2075,8 +2054,6 @@ fn backward_objects_query(
             format!("SELECT * FROM (({id_query}) UNION ALL ({key_query})) AS candidates",),
             id_bindings.into_iter().chain(key_bindings).collect(),
         )
-        .order_by("object_id")
-        .limit(page.limit() as i64)
     } else if let Ok(keys_filter) = HistoricalFilter::try_from(filter.clone()) {
         historical::query(page, &keys_filter)
     } else {


### PR DESCRIPTION
# Description of change

- `backward_view::merge_and_deduplicate` became `backward_view::merge` - the deduplicate step is not needed anymore as all sources are disjoint (do not contain duplicated objects) by construction (in case duplicates would appear in the result, it would mean that there is issue with the read queries, not that we need deduplication)
- the `historical.rs` view got upgraded with a `NOT EXISTS` check, to ensure that the same object version is not returned by both sources (`checkpointed_objects`, `objects_backward_history`)
- The object cursor got upgraded with object version and became `(object_id, object_version)`  to support paginating   many versions of the same object. This invalidates old cursors that contained just object id.
- The cursor bound uses a form: `object_id >= X AND (object_id > X OR object_version >= V)` instead of a `ROW()` comparison - the `ROW()` form produced slow plans when combined with an `objectKeys` filter (1.8s -> 0.4ms).
- The unused `RawPaginated`/`Target` cursor impls for `StoredHistoryObject` were removed - they we already dead code before this PR.

## Links to any relevant issues

fixes #11424

## How the change has been tested

Selected query plans checked with `EXPLAIN ANALYZE` on a testnet-sized DB (multi-key lookups, huge-version-history objects, cursors pointing between two versions of the same object): no regressions observed.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [x] GraphQL: An `objectKeys` filter can now return multiple versions of the same object; object cursors changed format, so cursors issued before the upgrade are invalid.


