### PR TITLE
feat(iota-protocol-config): sponsor Move authentication on all networks in v35

### DIFF
--- a/crates/iota-e2e-tests/tests/abstract_account_tests.rs
+++ b/crates/iota-e2e-tests/tests/abstract_account_tests.rs
@@ -1854,6 +1854,12 @@ async fn test_sponsored_tx_sender_aa_fails_post_consensus_when_only_sponsor_runs
     telemetry_subscribers::init_for_testing();
     let client_ip = SocketAddr::new([127, 0, 0, 1].into(), 0);
 
+    // Enable the flag so only the sponsor's MA runs pre-consensus.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_pre_consensus_sponsor_only_move_authentication_for_testing(true);
+        config
+    });
+
     // Sender is an AA with ED25519 authentication; sponsor is an AA with
     // free-access authentication.
     let mut test_env = TestEnvironment::new().await;
@@ -1999,6 +2005,12 @@ async fn test_non_sponsored_tx_sender_aa_rejected_pre_consensus_with_sponsor_onl
 -> Result<(), anyhow::Error> {
     let _pcool_guard = override_pcool_flow(false);
     telemetry_subscribers::init_for_testing();
+
+    // Enable the flag; it must not affect non-sponsored transactions.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_pre_consensus_sponsor_only_move_authentication_for_testing(true);
+        config
+    });
 
     let mut test_env = TestEnvironment::new().await;
     test_env

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
                 "passkey_auth": true,
                 "pcool_skip_immutable_object_locks": true,
                 "pcool_verifier_limits_from_protocol_config": true,
-                "pre_consensus_sponsor_only_move_authentication": true,
+                "pre_consensus_sponsor_only_move_authentication": false,
                 "protocol_defined_base_fee": true,
                 "publish_package_metadata": true,
                 "relocate_event_module": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -3467,6 +3467,14 @@ impl ProtocolConfig {
                         .consensus_enable_sliding_window_leader_schedule = true;
                     cfg.feature_flags
                         .consensus_enable_absolute_score_leader_schedule = true;
+
+                    // Enable Move-based sponsor account authentication on all
+                    // networks.
+                    cfg.feature_flags.enable_move_authentication_for_sponsor = true;
+                    // Run every `MoveAuthenticator` pre-consensus again, not
+                    // just the sponsor's, on all networks.
+                    cfg.feature_flags
+                        .pre_consensus_sponsor_only_move_authentication = false;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
@@ -37,6 +37,7 @@ feature_flags:
   metadata_in_module_bytes: true
   publish_package_metadata: true
   enable_move_authentication: true
+  enable_move_authentication_for_sponsor: true
   pass_validator_scores_to_advance_epoch: true
   consensus_fast_commit_sync: true
   consensus_block_restrictions: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_35.snap
@@ -44,7 +44,6 @@ feature_flags:
   consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
-  pre_consensus_sponsor_only_move_authentication: true
   consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   pcool_skip_immutable_object_locks: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_35.snap
@@ -51,7 +51,6 @@ feature_flags:
   consensus_block_restrictions: true
   move_native_tx_context: true
   additional_borrow_checks: true
-  pre_consensus_sponsor_only_move_authentication: true
   consensus_starfish_speed: true
   always_advance_dkg_to_resolution: true
   enable_pcool_flow: true


### PR DESCRIPTION
# Description of change

Protocol version 35 feature-flag changes:

- `enable_move_authentication_for_sponsor` → enabled on all networks. Mainnet had it turned off in v34; devnet and testnet already had it on.
- `pre_consensus_sponsor_only_move_authentication` → disabled on all networks. Every `MoveAuthenticator` on a transaction (sender's and sponsor's) is executed again in the pre-consensus phase, instead of only the sponsor's for sponsored transactions.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have checked that new and existing unit tests pass locally with my changes

Run locally:

- `cargo test -p iota-protocol-config` (snapshots for v35 on all three chains regenerated)
- `cargo simtest -p iota-e2e-tests --test abstract_account_tests` — 27/27 pass
- `cargo nextest run -p iota-adapter-transactional-tests -p iota-vm-sdk -p iota-types -p iota-protocol-config` — 599/599 pass
- `cargo nextest run -p iota-core --lib` — 860/860 pass
- `cargo clippy -p iota-protocol-config -p iota-core --all-targets -- -D warnings` — clean
- `generate-json-rpc-spec test` — spec matches


### Release Notes

- [x] Protocol: Enabled Move-based sponsor account authentication on all networks and runs every `MoveAuthenticator` pre-consensus again, not just the sponsor's.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:

<!-- Do not remove: everything below this line is ignored by the release-notes check. -->
