### PR TITLE
fix(iota-json-rpc): document the actual request_type default and drop the unused validation error (#12524)

### DIFF
--- a/crates/iota-json-rpc-api/src/write.rs
+++ b/crates/iota-json-rpc-api/src/write.rs
@@ -29,8 +29,7 @@ pub trait WriteApi {
     ///    client fires subsequent queries. However if the node fails to execute the
     ///    transaction locally in a timely manner, a bool type in the response is
     ///    set to false to indicated the case.
-    /// request_type is default to be `WaitForEffectsCert` unless
-    /// options.show_events or options.show_effects is true
+    /// request_type defaults to `WaitForEffectsCert` when omitted.
     #[rustfmt::skip]
     #[method(name = "executeTransactionBlock")]
     async fn execute_transaction_block(
@@ -43,7 +42,7 @@ pub trait WriteApi {
         signatures: Vec<Base64>,
         /// options for specifying the content to be returned
         options: Option<IotaTransactionBlockResponseOptions>,
-        /// The request type, derived from `IotaTransactionBlockResponseOptions` if None
+        /// The request type, `WaitForEffectsCert` if None
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<IotaTransactionBlockResponse>;
 

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -238,11 +238,6 @@ pub enum IotaRpcInputError {
     #[error("{0}")]
     GenericInvalid(String),
 
-    #[error(
-        "request_type` must set to `None` or `WaitForLocalExecution` if effects is required in the response"
-    )]
-    InvalidExecuteTransactionRequestType,
-
     #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
     ProtocolVersionUnsupported(u64, u64),
 

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -313,7 +313,7 @@
           "name": "Write API"
         }
       ],
-      "description": "Execute the transaction and wait for results if desired. Request types: 1. WaitForEffectsCert: waits for TransactionEffectsCert and then return to    client. This mode is a proxy for transaction finality. 2. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the    node executed the transaction locally before returning the client. The    local execution makes sure this node is aware of this transaction when    client fires subsequent queries. However if the node fails to execute the    transaction locally in a timely manner, a bool type in the response is    set to false to indicated the case. request_type is default to be `WaitForEffectsCert` unless options.show_events or options.show_effects is true",
+      "description": "Execute the transaction and wait for results if desired. Request types: 1. WaitForEffectsCert: waits for TransactionEffectsCert and then return to    client. This mode is a proxy for transaction finality. 2. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the    node executed the transaction locally before returning the client. The    local execution makes sure this node is aware of this transaction when    client fires subsequent queries. However if the node fails to execute the    transaction locally in a timely manner, a bool type in the response is    set to false to indicated the case. request_type defaults to `WaitForEffectsCert` when omitted.",
       "params": [
         {
           "name": "tx_bytes",
@@ -343,7 +343,7 @@
         },
         {
           "name": "request_type",
-          "description": "The request type, derived from `IotaTransactionBlockResponseOptions` if None",
+          "description": "The request type, `WaitForEffectsCert` if None",
           "schema": {
             "$ref": "#/components/schemas/ExecuteTransactionRequestType"
           }


### PR DESCRIPTION
# Description of change

- The `iota_executeTransactionBlock` doc promised a `request_type` default derived from the response options. The handler applies `WaitForEffectsCert` unconditionally. The doc now states the actual default.
- The unconditional default is kept on purpose. Deriving it from options would silently move omitted-field clients onto the skip-certification path. That path's timeout semantics are still an open decision in #12414.
- The unused `IotaRpcInputError::InvalidExecuteTransactionRequestType` variant is removed. The rule it describes was never enforced.
- The OpenRPC spec is regenerated from the updated doc.

No wire behavior changes.

## Links to any relevant issues

Fixes #12524. This implements the issue's second proposed direction: document the actual unconditional default and remove the unused validation variant.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
