### PR TITLE
feat(iota-protocol-config): enable the redesigned leader schedule on mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -224,6 +224,9 @@ pub const PROTOCOL_VERSION_IIP8: u64 = 20;
 //             (inert where the P-COOL flow is off).
 //             Start publishing package metadata using module metadata as a
 //             dynamic field on mainnet.
+//             Enable the redesigned leader schedule (sliding-window reputation
+//             scoring and absolute-score bad-node selection) in Starfish
+//             consensus on mainnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3457,6 +3460,13 @@ impl ProtocolConfig {
                     // dynamic field.
                     cfg.feature_flags
                         .package_metadata_with_dynamic_module_metadata = true;
+                    // Enable the redesigned leader schedule: sliding-window
+                    // reputation scoring and absolute-score bad-node
+                    // selection.
+                    cfg.feature_flags
+                        .consensus_enable_sliding_window_leader_schedule = true;
+                    cfg.feature_flags
+                        .consensus_enable_absolute_score_leader_schedule = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_35.snap
@@ -49,6 +49,8 @@ feature_flags:
   validator_metadata_verify_v2: true
   package_metadata_with_dynamic_module_metadata: true
   report_move_authentication_error: true
+  consensus_enable_sliding_window_leader_schedule: true
+  consensus_enable_absolute_score_leader_schedule: true
   max_ptb_value_size_v2: true
   allow_unbounded_system_objects: true
 max_tx_size_bytes: 131072


### PR DESCRIPTION
# Description of change

Enable the redesigned leader schedule (sliding-window reputation scoring and absolute-score bad-node selection) in Starfish consensus on mainnet, in protocol version 35. Devnet (v32) and testnet (v33) already run it.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable the redesigned leader schedule (sliding-window reputation scoring and absolute-score bad-node selection) in Starfish consensus on mainnet.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] gRPC:
