### PR TITLE
fix(starfish): evict shards at the GC round of the last commit

### DIFF
--- a/crates/starfish/core/src/cordial_knowledge.rs
+++ b/crates/starfish/core/src/cordial_knowledge.rs
@@ -74,7 +74,7 @@ pub(crate) struct CordialKnowledge {
     /// and AuthorityService
     cordial_knowledge_receiver: Receiver<CordialKnowledgeMessage>,
     /// Receives eviction rounds from DagState (latest-only).
-    eviction_rounds_receiver: tokio::sync::watch::Receiver<Vec<Round>>,
+    eviction_rounds_receiver: tokio::sync::watch::Receiver<EvictionRounds>,
     /// Latest round per author whose shards are useful to fetch from peers:
     /// we know of the block header but lack its payload. Global input from
     /// which each peer's shard requests are selected.
@@ -273,7 +273,7 @@ impl CordialKnowledge {
         Self,
         Vec<Arc<RwLock<ConnectionKnowledge>>>,
         Sender<CordialKnowledgeMessage>,
-        tokio::sync::watch::Sender<Vec<Round>>,
+        tokio::sync::watch::Sender<EvictionRounds>,
     ) {
         let num_authorities = context.committee.size();
 
@@ -283,7 +283,7 @@ impl CordialKnowledge {
             Receiver<CordialKnowledgeMessage>,
         ) = monitored_mpsc::channel("cordial_knowledge", CORDIAL_KNOWLEDGE_CHANNEL_CAPACITY);
         let (eviction_rounds_sender, eviction_rounds_receiver) =
-            tokio::sync::watch::channel(Vec::new());
+            tokio::sync::watch::channel(EvictionRounds::default());
 
         let mut connection_knowledges = Vec::with_capacity(num_authorities);
 
@@ -442,10 +442,10 @@ impl CordialKnowledge {
             return;
         }
         let evicted_rounds = self.eviction_rounds_receiver.borrow_and_update().clone();
-        if evicted_rounds.len() != self.context.committee.size() {
+        if evicted_rounds.headers.len() != self.context.committee.size() {
             warn!(
                 "Eviction rounds length {} does not match committee size {}; skipping eviction",
-                evicted_rounds.len(),
+                evicted_rounds.headers.len(),
                 self.context.committee.size()
             );
             return;
@@ -846,12 +846,12 @@ impl CordialKnowledge {
     /// Called when older rounds should be pruned globally.
     fn handle_evict_below(
         &mut self,
-        evicted_rounds: Vec<Round>,
+        evicted_rounds: EvictionRounds,
     ) -> Option<Vec<Vec<ConnectionKnowledgeMessage>>> {
         // Evict locally
         for (index, btree_map) in &mut self.cordial_knowledge.iter_mut().enumerate() {
             // Increase by 1 for splitting as the evicted rounds are gone from memory
-            let split_round = evicted_rounds[index] + 1;
+            let split_round = evicted_rounds.headers[index] + 1;
             // Remove everything strictly below this round
             *btree_map = btree_map.split_off(&split_round);
         }
@@ -862,7 +862,7 @@ impl CordialKnowledge {
     #[inline]
     fn prepare_evict_msgs(
         &self,
-        rounds: Vec<Round>,
+        rounds: EvictionRounds,
     ) -> Option<Vec<Vec<ConnectionKnowledgeMessage>>> {
         let mut vec_msgs: Vec<Vec<ConnectionKnowledgeMessage>> =
             Vec::with_capacity(self.cordial_knowledge.len());
@@ -1042,8 +1042,16 @@ pub enum ConnectionKnowledgeMessage {
         useful_headers_to_peer: BTreeMap<AuthorityIndex, Round>,
         useful_shards_to_peer: BTreeMap<AuthorityIndex, Round>,
     },
-    /// Global eviction (prune below round)
-    EvictBelow(Vec<Round>),
+    /// Global eviction (prune at or below the rounds)
+    EvictBelow(EvictionRounds),
+}
+
+/// Rounds at or below which DagState evicted after a flush: headers per
+/// author, shards for all authors.
+#[derive(Clone, Debug, Default)]
+pub struct EvictionRounds {
+    pub headers: Vec<Round>,
+    pub shards: Round,
 }
 
 /// Manages the knowledge state for a single connection to a peer.
@@ -1220,7 +1228,10 @@ impl ConnectionKnowledge {
                 self.handle_remove_shard(gen_tx_ref);
             }
             ConnectionKnowledgeMessage::EvictBelow(rounds) => {
-                self.evict_below(rounds);
+                self.evict_below(rounds.headers);
+                for map in self.shards_not_known.iter_mut() {
+                    *map = map.split_off(&(rounds.shards + 1));
+                }
             }
             ConnectionKnowledgeMessage::SetUsefulHeadersFromPeer(authorities_with_round) => {
                 self.set_useful_headers_from(authorities_with_round);
@@ -1500,7 +1511,44 @@ mod tests {
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
+        transaction_ref::TransactionRef,
     };
+
+    /// Shard knowledge is pruned at the shard round, independently of the
+    /// per-author header rounds.
+    #[tokio::test]
+    async fn test_evict_below_prunes_shard_knowledge_at_shard_round() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let mut connection_knowledge = ConnectionKnowledge::new(context.clone(), dag_state);
+        let author = AuthorityIndex::new_for_test(1);
+        for round in [3, 14, 15, 20] {
+            connection_knowledge.process_one_message(ConnectionKnowledgeMessage::NewShard {
+                gen_tx_ref: GenericTransactionRef::TransactionRef(TransactionRef {
+                    round,
+                    author,
+                    transactions_commitment: TransactionsCommitment::MIN,
+                }),
+            });
+        }
+
+        connection_knowledge.process_one_message(ConnectionKnowledgeMessage::EvictBelow(
+            EvictionRounds {
+                headers: vec![GENESIS_ROUND; context.committee.size()],
+                shards: 14,
+            },
+        ));
+
+        let remaining = connection_knowledge.shards_not_known[author]
+            .keys()
+            .copied()
+            .collect::<Vec<Round>>();
+        assert_eq!(remaining, vec![15, 20]);
+    }
 
     fn cordial_knowledge_for_test(
         validators: usize,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -36,7 +36,7 @@ use crate::{
         GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
-    cordial_knowledge::CordialKnowledgeMessage,
+    cordial_knowledge::{CordialKnowledgeMessage, EvictionRounds},
     error::ConsensusResult,
     leader_scoring::{ReputationScores, ScoringSubdag},
     misbehavior_store::{MisbehaviorCounts, MisbehaviorStore},
@@ -263,7 +263,7 @@ pub(crate) struct DagState {
     /// Contains recent own serialized shards with their Merkle proofs per
     /// authority. To access own shard for a given transaction_ref, one
     /// needs to read first the entry with index transaction_ref.author.
-    /// Eviction is aligned with headers
+    /// Evicted at the GC round of the last commit.
     recent_shards_by_authority: Vec<BTreeMap<GenericTransactionRef, Bytes>>,
     /// Indexes recent block headers refs by their authorities.
     /// Vec position corresponds to the authority index.
@@ -359,7 +359,10 @@ pub(crate) struct DagState {
     cached_rounds: Round,
 
     /// Cordial Knowledge senders (main updates, eviction rounds).
-    cordial_knowledge_senders: Option<(Sender<CordialKnowledgeMessage>, watch::Sender<Vec<Round>>)>,
+    cordial_knowledge_senders: Option<(
+        Sender<CordialKnowledgeMessage>,
+        watch::Sender<EvictionRounds>,
+    )>,
 
     /// History of strong-vote complaint masks against this node's own
     /// leader rounds, keyed by leader round.
@@ -521,7 +524,7 @@ impl DagState {
     pub fn set_cordial_knowledge_senders(
         &mut self,
         sender: Sender<CordialKnowledgeMessage>,
-        eviction_sender: watch::Sender<Vec<Round>>,
+        eviction_sender: watch::Sender<EvictionRounds>,
     ) {
         self.cordial_knowledge_senders = Some((sender, eviction_sender));
     }
@@ -2294,11 +2297,11 @@ impl DagState {
         }
     }
 
-    /// Clean up old shards. Used after flushing.
+    /// Evicts shards at or below the GC round of the last commit, including
+    /// those of blocks that were never accepted. Used after flushing.
     pub(crate) fn evict_shards(&mut self) {
+        let eviction_round = self.gc_round_for_last_commit();
         for (authority_index, _) in self.context.committee.authorities() {
-            let eviction_round = self.calculate_authority_eviction_round(authority_index);
-
             // Evict everything below split_key
             let split_key = GenericTransactionRef::from(TransactionRef {
                 round: eviction_round + 1,
@@ -2410,7 +2413,13 @@ impl DagState {
                 let eviction_round = self.calculate_authority_eviction_round(authority_index);
                 eviction_rounds.push(eviction_round);
             }
-            if eviction_sender.send(eviction_rounds).is_err() {
+            if eviction_sender
+                .send(EvictionRounds {
+                    headers: eviction_rounds,
+                    shards: self.gc_round_for_last_commit(),
+                })
+                .is_err()
+            {
                 warn!("Failed to send cordial knowledge eviction message: channel closed");
             }
         }
@@ -4608,6 +4617,63 @@ mod test {
         assert_eq!(
             cached_headers.last().map(|header| header.round()),
             Some(last_accepted_round)
+        );
+    }
+
+    /// Shards are evicted at the GC round even for an author without accepted
+    /// headers.
+    #[tokio::test]
+    async fn test_shard_eviction_without_accepted_headers() {
+        const NUM_ROUNDS: Round = 20;
+        let (mut context, _) = Context::new_for_test(4);
+        context.protocol_config.set_gc_depth_for_testing(3);
+        let context = Arc::new(context);
+        let mut dag_state = DagState::new(context.clone(), Arc::new(MemStore::new()));
+
+        let author = AuthorityIndex::new_for_test(3);
+        let shard_refs = (1..=NUM_ROUNDS)
+            .map(|round| {
+                GenericTransactionRef::from(TransactionRef {
+                    round,
+                    author,
+                    transactions_commitment: TransactionsCommitment::MIN,
+                })
+            })
+            .collect::<Vec<_>>();
+        for &gen_transaction_ref in &shard_refs {
+            dag_state.add_shard(VerifiedOwnShard {
+                serialized_shard: Bytes::from_static(&[0u8; 8]),
+                gen_transaction_ref,
+            });
+        }
+        let leader = BlockRef::new(
+            NUM_ROUNDS,
+            AuthorityIndex::new_for_test(0),
+            BlockHeaderDigest::MIN,
+        );
+        dag_state.set_last_commit(TrustedCommit::new_for_test(
+            &context,
+            1,
+            CommitDigest::MIN,
+            0,
+            leader,
+            vec![leader],
+            vec![],
+        ));
+
+        dag_state.flush();
+
+        let gc_round = dag_state.gc_round_for_last_commit();
+        assert_eq!(gc_round, NUM_ROUNDS - 6);
+        let cached_rounds = dag_state
+            .get_cached_shards(&shard_refs)
+            .into_iter()
+            .zip(1..=NUM_ROUNDS)
+            .filter_map(|(shard, round)| shard.map(|_| round))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            cached_rounds,
+            (gc_round + 1..=NUM_ROUNDS).collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
# Description of change

- `DagState::add_shard` stores the local node's shard of every verified streamed block, whether the block manager accepted, suspended or dropped the block. `evict_shards` removed an author's shards only below `min(gc_round, last_accepted_round(author) - cached_rounds)`, the bound used for headers. For an author whose streamed blocks are not accepted, that bound does not move while the GC round advances, so its shards stayed in `DagState`, and a reference per connection stayed in `shards_not_known`, for the rest of the epoch.
- Shards are now evicted at the GC round of the last commit for every author. A block at or below that round can no longer be sequenced, so nothing useful is lost; the per-author term only delayed eviction. The eviction message to the connection knowledge carries that round next to the per-author header rounds, and each connection prunes its shard references with it.

## Links to any relevant issues

Fixes iotaledger/iota-private#515

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
